### PR TITLE
稍作修改即可支持 reCaptcha

### DIFF
--- a/chrome/js/background.js
+++ b/chrome/js/background.js
@@ -2,12 +2,14 @@ chrome.webRequest.onBeforeRequest.addListener(
     function(request) {
         var url = request.url.replace('googleapis.com', 'lug.ustc.edu.cn');
         url = url.replace('themes.googleusercontent.com', 'google-themes.lug.ustc.edu.cn');
+        url = url.replace('www.google.com/recaptcha/','www.recaptcha.net/recaptcha/');
         return {redirectUrl: url};
     },
     {
         urls: [
             "*://ajax.googleapis.com/*",
-            "*://themes.googleusercontent.com/*"
+            "*://themes.googleusercontent.com/*",
+            "*://www.google.com/recaptcha/*"
         ]
     },
     ["blocking"]


### PR DESCRIPTION
虽然稍稍有点偏离“替换CDN”的最初用意，但是将Google的reCaptcha验证一并支持能起到更加方便的效果。

仅仅替换`www.google.com/recaptcha/`到`www.recaptcha.net/recaptcha/`即可。

Firefox版本未作调整。