### PR TITLE
重新启用对google fonts的CDN替换

### DIFF
--- a/chrome/js/background.js
+++ b/chrome/js/background.js
@@ -8,6 +8,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     {
         urls: [
             "*://ajax.googleapis.com/*",
+            "*://fonts.googleapis.com/*",
             "*://themes.googleusercontent.com/*",
             "*://www.google.com/recaptcha/*"
         ]

--- a/firfox/js/background.js
+++ b/firfox/js/background.js
@@ -7,6 +7,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     {
         urls: [
             "*://ajax.googleapis.com/*",
+            "*://fonts.googleapis.com/*",
             "*://themes.googleusercontent.com/*"
         ]
     },


### PR DESCRIPTION
直接访问 fonts.googleapis.com 失败（北京，2019-7-12），使用 #17 中的方法发现 fonts.ustc.edu.cn 也没有重定向回 fonts.googleapis.com。 所以可能需要将该域重新进行 cdn 替换。

``` bash
$ curl -iI https://fonts.googleapis.com/css?family=Lato
curl: (7) Failed to connect to fonts.googleapis.com port 443: Operation timed out

$ curl -iI https://fonts.lug.ustc.edu.cn/css?family=Lato
HTTP/2 301
server: nginx
date: Fri, 12 Jul 2019 11:04:24 GMT
content-type: text/html
content-length: 178
location: https://fonts.proxy.ustclug.org/css?family=Lato
```