### PR TITLE
Add browser publish github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: "submit"
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Zip Extension
+        run: npm run build
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v0.0.0
+        with:
+          artifact: "extension.zip"
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+extension.zip

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "fmt": "prettier --write \"extension/**/*.{ts,js}\""
+    "fmt": "prettier --write \"extension/**/*.{ts,js}\"",
+    "build": "cd extension/; zip -r ../extension.zip .; cd -"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.139",


### PR DESCRIPTION
Hey @justjavac, we created a [Github action](https://github.com/marketplace/actions/browser-plugin-publisher) to make it easier to publish extensions to the various web stores.

Thought you might find it useful so I added a build step (just zips the extension folder) and added a Github workflow that will run the build step and publish to the web stores on dispatch. 

The only thing you would need to create is a SUBMIT_KEYS GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key:

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/main/keys.schema.json",
  "chrome": {
    "zip": "./extension.crx",
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./extension.xpi",
    "extId": "123",
    "sessionid": "abcd"
  }
}
```
You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!