### PR TITLE
Upgrade bpp to v2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Zip Extension
         run: npm run build
       - name: Browser Plugin Publish
-        uses: plasmo-corp/bpp@v0.0.0
+        uses: PlasmoHQ/bpp@v2
         with:
           artifact: "extension.zip"
           keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Upgrades the Browser Plugin Publish Github action to v2. This adds new features like using the Edge Add-ons API and improved reliability. 

We also renamed our organization which is why that's different now.