### PR TITLE
 cdn.jsdelivr.net replace to fastly.jsdelivr.net 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ server/*
 extension/_metadata/
 extension/test/extension-v3-test/_metadata/
 extension/test/chromium-tools/
-
+extension/test/extension-v3-test/chromium-browser/
+extension/test/extension-v3-test/claat-linux-amd64
+extension/test/extension-v3-test/replace-google-frontend-cdn/

--- a/CHANGELOG-0.10.x.md
+++ b/CHANGELOG-0.10.x.md
@@ -8,6 +8,7 @@
 >2. 新增 `cdnjs.cloudflare.com` - 替换为 `cdnjs.loli.net` 默认未启用
 >3. 新增 公共 CDN 静态资源库 极客族公共加速服务 `https://cdn.geekzu.org/cached.html`
 >4. 新增 公共 CDN 静态资源库 七牛静态库 `http://staticfile.org/`
+>5. 新增 通过国内镜像 克隆本项目源代码
 
 ## CHANGELOG for 0.10.4
 ### 变更

--- a/CHANGELOG-0.10.x.md
+++ b/CHANGELOG-0.10.x.md
@@ -4,8 +4,8 @@
 ## [一个完整的 测试环境例子 `extension/test/extension-v3-test` ](/extension/test/extension-v3-test/README.md)
 
 ## CHANGELOG for 0.10.5
->1. 新增 `cdn.jsdelivr.net` - cdnjs 替换为 `fastly.jsdelivr.net`
->2. 新增 `cdnjs.cloudflare.com` - cdnjs 替换为 `cdnjs.loli.net` 默认未启用
+>1. 新增 `cdn.jsdelivr.net` - 替换为 `fastly.jsdelivr.net`
+>2. 新增 `cdnjs.cloudflare.com` - 替换为 `cdnjs.loli.net` 默认未启用
 >3. 新增 公共 CDN 静态资源库 极客族公共加速服务 `https://cdn.geekzu.org/cached.html`
 >4. 新增 公共 CDN 静态资源库 七牛静态库 `http://staticfile.org/`
 

--- a/CHANGELOG-0.10.x.md
+++ b/CHANGELOG-0.10.x.md
@@ -3,6 +3,12 @@
 ## [测试用例](/extension/test/README.md)
 ## [一个完整的 测试环境例子 `extension/test/extension-v3-test` ](/extension/test/extension-v3-test/README.md)
 
+## CHANGELOG for 0.10.5
+>1. 新增 `cdn.jsdelivr.net` - cdnjs 替换为 `fastly.jsdelivr.net`
+>2. 新增 `cdnjs.cloudflare.com` - cdnjs 替换为 `cdnjs.loli.net` 默认未启用
+>3. 新增 公共 CDN 静态资源库 极客族公共加速服务 `https://cdn.geekzu.org/cached.html`
+>4. 新增 公共 CDN 静态资源库 七牛静态库 `http://staticfile.org/`
+
 ## CHANGELOG for 0.10.4
 ### 变更
 >1. 修复 `www.google.com/recaptcha/` 无法显示问题； 通过新增 `extension/rules/rules_redirect_1_extra.json`实现

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Chrome 安装方法（Google 被墙了上不去）：
 > 5. 这就安装好了，去掉 Developer Mode 勾选。
 
 
-###  手动安装  (来自国内镜像) 克隆源代码以后， 步骤如上:	&#x2b06; &#xfe0f;
+###  手动安装  (来自国内镜像) 克隆源代码以后， 步骤如上：	:point_up_2:
 ```shell 
 # 克隆源代码
 git clone -b master https://gitee.com/mirrors/replacegooglecdn.git --depth=1 --progress 

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ Chrome 安装方法（Google 被墙了上不去）：
 > 5. 这就安装好了，去掉 Developer Mode 勾选。
 
 
-###  手动安装  (来自国内镜像) 克隆源代码以后， 步骤如上：	:point_up_2:
+###  手动安装  (来自国内镜像) 克隆源代码以后， 步骤如上：	:point_up_2:	:point_up_2:	:point_up_2:
 ```shell 
 # 克隆源代码
 git clone -b master https://gitee.com/mirrors/replacegooglecdn.git --depth=1 --progress 
 
-# update source code  更新源代码
+# 更新源代码
 
 git -C replacegooglecdn pull  --depth=1 --progress  --rebase=true
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@
 1. `secure.gravatar.com` - gravatar 头像，替换为 `gravatar.loli.net`
 1. `maxcdn.bootstrapcdn.com/bootstrap` - bootstrap 框架使用的 CDN，替换为 `lib.baomitu.com/twitter-bootstrap/`
 1. `code.jquery.com/jquery-(version)(suffix)` - jquery 框架使用的 CDN，替换为 `lib.baomitu.com/jquery/$verson/$suffix`
-1. `cdnjs.cloudflare.com` - cdnjs 替换为 `cdnjs.loli.net`  默认未启用
+1. `cdnjs.cloudflare.com` - cdnjs 替换为 `cdnjs.loli.net`   默认未启用,  需要请自行打开
+1. `cdn.jsdelivr.net` - cdnjs 替换为 `fastly.jsdelivr.net`  默认未启用, 需要请自行打开
 
 ## 功能变更记录[`CHANGELOG-0.10.x`](CHANGELOG-0.10.x.md)
+
+## [可用 公共 CDN 静态资源库 和 网络拨测工具](extension/rules/README.md)
 
 ## 效果
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 1. `secure.gravatar.com` - gravatar 头像，替换为 `gravatar.loli.net`
 1. `maxcdn.bootstrapcdn.com/bootstrap` - bootstrap 框架使用的 CDN，替换为 `lib.baomitu.com/twitter-bootstrap/`
 1. `code.jquery.com/jquery-(version)(suffix)` - jquery 框架使用的 CDN，替换为 `lib.baomitu.com/jquery/$verson/$suffix`
-1. `cdnjs.cloudflare.com` - cdnjs 替换为 `cdnjs.loli.net`   默认未启用,  需要请自行打开
-1. `cdn.jsdelivr.net` - cdnjs 替换为 `fastly.jsdelivr.net`
+1. `cdnjs.cloudflare.com` - 替换为 `cdnjs.loli.net`   默认未启用,  需要请自行打开
+1. `cdn.jsdelivr.net` - 替换为 `fastly.jsdelivr.net`
 
 ## 功能变更记录[`CHANGELOG-0.10.x`](CHANGELOG-0.10.x.md)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 1. `maxcdn.bootstrapcdn.com/bootstrap` - bootstrap 框架使用的 CDN，替换为 `lib.baomitu.com/twitter-bootstrap/`
 1. `code.jquery.com/jquery-(version)(suffix)` - jquery 框架使用的 CDN，替换为 `lib.baomitu.com/jquery/$verson/$suffix`
 1. `cdnjs.cloudflare.com` - cdnjs 替换为 `cdnjs.loli.net`   默认未启用,  需要请自行打开
-1. `cdn.jsdelivr.net` - cdnjs 替换为 `fastly.jsdelivr.net`  默认未启用, 需要请自行打开
+1. `cdn.jsdelivr.net` - cdnjs 替换为 `fastly.jsdelivr.net`
 
 ## 功能变更记录[`CHANGELOG-0.10.x`](CHANGELOG-0.10.x.md)
 

--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ Chrome 安装方法（Google 被墙了上不去）：
 > 5. 这就安装好了，去掉 Developer Mode 勾选。
 
 
+###  手动安装  (来自国内镜像) 克隆源代码以后， 步骤如上:	&#x2b06; &#xfe0f;
+```shell 
+# 克隆源代码
+git clone -b master https://gitee.com/mirrors/replacegooglecdn.git --depth=1 --progress 
+
+# update source code  更新源代码
+
+git -C replacegooglecdn pull  --depth=1 --progress  --rebase=true
+
+``````

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -42,8 +42,13 @@
             },
             {
                 "id": "ruleset_domain_replace_1",
-                "enabled": true,
+                "enabled": false,
                 "path": "rules/rules-domain-replace.json"
+            },
+            {
+                "id": "ruleset_cdn-jsdelivr-net_replace",
+                "enabled": true,
+                "path": "rules/rules-cdn-jsdelivr-net-redirect.json"
             }
         ]
     },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -39,6 +39,11 @@
                 "id": "ruleset_remove_header_1",
                 "enabled": true,
                 "path": "rules/rules_remove_header_1.json"
+            },
+            {
+                "id": "ruleset_domain_replace_1",
+                "enabled": true,
+                "path": "rules/rules-domain-replace.json"
             }
         ]
     },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Replace Google CDN",
-    "version": "0.10.4",
+    "version": "0.10.5",
     "manifest_version": 3,
     "icons": {
       "128": "icons/128.png"

--- a/extension/rules/README.md
+++ b/extension/rules/README.md
@@ -17,6 +17,7 @@
 9. [cloudflare ](https://cdnjs.com/)
 10. [google libraries](https://developers.google.com/speed/libraries)
 11. [中科大反向代理列表如下：](https://mirrors.ustc.edu.cn/)
+12. [七牛静态库](http://staticfile.org/)
 
 ```text
 

--- a/extension/rules/README.md
+++ b/extension/rules/README.md
@@ -16,8 +16,9 @@
 8. [unpkg](https://unpkg.com/)
 9. [cloudflare ](https://cdnjs.com/)
 10. [google libraries](https://developers.google.com/speed/libraries)
-11. [中科大反向代理列表如下：](https://mirrors.ustc.edu.cn/)
-12. [七牛静态库](http://staticfile.org/)
+11. [七牛静态库](http://staticfile.org/)
+12. [极客族公共加速服务](https://cdn.geekzu.org/cached.html)
+13. [中科大反向代理列表如下：](https://mirrors.ustc.edu.cn/)
 
 ```text
 
@@ -86,7 +87,7 @@ google-themes.proxy.ustclug.org
 }
 
 ```
-## 动态匹配域名
+### 动态匹配域名
 
 > https://www.chromium.org/   ->    https://2_www_xn--3px_chromium_xn--3px_org.proxy.domain.com/
 
@@ -98,7 +99,7 @@ google-themes.proxy.ustclug.org
 }
 ```
 
-### 阻止指定域名
+### 阻止指定域名 (拦截请求)
 ```json
 
 {
@@ -109,4 +110,12 @@ google-themes.proxy.ustclug.org
 
 ```
 
+
+### 修改 http 请求头或者响应头
+```json
+{
+  "id": "ruleset_remove_header_1",
+  "enabled": true,
+  "path": "rules/rules_remove_header_1.json"
+}
 

--- a/extension/rules/rules-cdn-jsdelivr-net-redirect.json
+++ b/extension/rules/rules-cdn-jsdelivr-net-redirect.json
@@ -1,15 +1,22 @@
 [
+
   {
     "id": 1,
-    "priority": 1,
+    "priority": 10,
     "action": {
       "type": "redirect",
       "redirect": {
-        "transform": { "scheme": "https", "host": "cdnjs.loli.net" }
+        "transform": {
+          "scheme": "https",
+          "host": "fastly.jsdelivr.net"
+        }
       }
     },
     "condition": {
-      "urlFilter": "cdnjs.cloudflare.com/ajax/libs",
+      "urlFilter": "cdn.jsdelivr.net",
+      "requestDomains":[
+        "cdn.jsdelivr.net"
+      ],
       "resourceTypes": [
         "main_frame", "sub_frame", "stylesheet", "script", "image", "font",
         "object", "xmlhttprequest", "ping", "csp_report", "media", "websocket",

--- a/extension/rules/rules-domain-replace.json
+++ b/extension/rules/rules-domain-replace.json
@@ -1,0 +1,36 @@
+[
+
+  {
+    "id": 1,
+    "priority": 10,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "scheme": "https",
+          "host": "fastly.jsdelivr.net"
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "cdn.jsdelivr.net",
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "webtransport",
+        "webbundle",
+        "other"
+      ]
+    }
+  }
+]

--- a/extension/rules/rules-domain-replace.json
+++ b/extension/rules/rules-domain-replace.json
@@ -1,35 +1,22 @@
 [
-
   {
     "id": 1,
-    "priority": 10,
+    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {
-        "transform": {
-          "scheme": "https",
-          "host": "fastly.jsdelivr.net"
-        }
+        "transform": { "scheme": "https", "host": "cdnjs.loli.net" }
       }
     },
     "condition": {
-      "urlFilter": "cdn.jsdelivr.net",
+      "urlFilter": "cdnjs.cloudflare.com/ajax/libs",
+      "requestDomains":[
+        "cdnjs.cloudflare.com"
+      ],
       "resourceTypes": [
-        "main_frame",
-        "sub_frame",
-        "stylesheet",
-        "script",
-        "image",
-        "font",
-        "object",
-        "xmlhttprequest",
-        "ping",
-        "csp_report",
-        "media",
-        "websocket",
-        "webtransport",
-        "webbundle",
-        "other"
+        "main_frame", "sub_frame", "stylesheet", "script", "image", "font",
+        "object", "xmlhttprequest", "ping", "csp_report", "media", "websocket",
+        "webtransport", "webbundle", "other"
       ]
     }
   }

--- a/extension/test/README.md
+++ b/extension/test/README.md
@@ -5,4 +5,4 @@
 2. [Google reCAPTCHA  打开 `https://patrickhlauke.github.io/recaptcha/` 查看结果](https://patrickhlauke.github.io/recaptcha/)
 3. [ `pub.dev` 域名下 `fonts.googleapis.com` 无法地址重定向； 打开  `https://pub.dev/` 查看结果](https://pub.dev/)
 4. [`cdn.jsdelivr.net` 替换为 `fastly.jsdelivr.net` 打开  `https://www.jsdelivr.com/` 查看结果  ](https://www.jsdelivr.com/)
-4. [`cdnjs.cloudflare.com` 替换为 `cdnjs.loli.net` 打开  `https://www.jsdelivr.com/` 查看结果  ](https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.1.2/reveal.min.css)
+4. [`cdnjs.cloudflare.com` 替换为 `cdnjs.loli.net` 打开  `https://cdnjs.cloudflare.com/` 查看结果  ](https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.1.2/reveal.min.css)

--- a/extension/test/README.md
+++ b/extension/test/README.md
@@ -1,6 +1,8 @@
 # 测试用例
 > 打开 dev-tools 面板查看请求
 
-1. [stackoverflow 打开 test `https://patrickhlauke.github.io/recaptcha/ `](https://stackoverflow.com/tags/socat/hot?filter=all)
-2. [Google reCAPTCHA  打开 test `https://patrickhlauke.github.io/recaptcha/ `](https://patrickhlauke.github.io/recaptcha/)
-3. [`pub.dev`域名下`fonts.googleapis.com`无法地址重定向； 打开 test](https://pub.dev/)
+1. [stackoverflow  打开 `https://stackoverflow.com/tags/socat/hot?filter=all` 查看结果](https://stackoverflow.com/tags/socat/hot?filter=all)
+2. [Google reCAPTCHA  打开 `https://patrickhlauke.github.io/recaptcha/` 查看结果](https://patrickhlauke.github.io/recaptcha/)
+3. [ `pub.dev` 域名下 `fonts.googleapis.com` 无法地址重定向； 打开  `https://pub.dev/` 查看结果](https://pub.dev/)
+4. [`cdn.jsdelivr.net` 替换为 `fastly.jsdelivr.net` 打开  `https://www.jsdelivr.com/` 查看结果  ](https://www.jsdelivr.com/)
+4. [`cdnjs.cloudflare.com` 替换为 `cdnjs.loli.net` 打开  `https://www.jsdelivr.com/` 查看结果  ](https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.1.2/reveal.min.css)

--- a/extension/test/README.md
+++ b/extension/test/README.md
@@ -5,4 +5,4 @@
 2. [Google reCAPTCHA  打开 `https://patrickhlauke.github.io/recaptcha/` 查看结果](https://patrickhlauke.github.io/recaptcha/)
 3. [ `pub.dev` 域名下 `fonts.googleapis.com` 无法地址重定向； 打开  `https://pub.dev/` 查看结果](https://pub.dev/)
 4. [`cdn.jsdelivr.net` 替换为 `fastly.jsdelivr.net` 打开  `https://www.jsdelivr.com/` 查看结果  ](https://www.jsdelivr.com/)
-4. [`cdnjs.cloudflare.com` 替换为 `cdnjs.loli.net` 打开  `https://cdnjs.cloudflare.com/` 查看结果  ](https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.1.2/reveal.min.css)
+5. [`cdnjs.cloudflare.com` 替换为 `cdnjs.loli.net` 打开  `https://cdnjs.cloudflare.com/` 查看结果  ](https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.1.2/reveal.min.css)

--- a/extension/test/extension-v3-test/README.md
+++ b/extension/test/extension-v3-test/README.md
@@ -46,7 +46,7 @@
 {
     "id": "ruleset_advance_redirect_1",
     "enabled": true,
-    "path": "test/extension-v3-test/rules_advance_redirect_1.json"
+    "path": "rules/rules_advance_redirect_1.json"
 }
 
 ```
@@ -64,7 +64,7 @@
 {
     "id": "ruleset_advance_redirect_2",
     "enabled": true,
-    "path": "test/extension-v3-test/rules_advance_redirect_2.json"
+    "path": "rules/rules_advance_redirect_2.json"
 }
 ```
 
@@ -75,7 +75,7 @@
 {
     "id": "ruleset_block_header_1",
     "enabled": true,
-    "path": "test/extension-v3-test/rules_block_1.json"
+    "path": "rules/rules_block_1.json"
 }
 
 ```

--- a/extension/test/extension-v3-test/README.md
+++ b/extension/test/extension-v3-test/README.md
@@ -1,7 +1,7 @@
 ## chromium extension v3 
 > 一个完整的 测试例子
 
-## manifeset.json 参考 declarative_net_request 配置
+## 一：manifest.json  declarative_net_reques 高级配置示例
 ```json
  {
     "declarative_net_request" :{
@@ -32,8 +32,8 @@
 
 ```
 
-## manifest.json  declarative_net_reques 高级配置示例
-### 匹配指定域名
+
+## 二：匹配指定域名
 
 > `github.com`  -> `github-com.proxy.domain.com`
 
@@ -50,7 +50,7 @@
 }
 
 ```
-## 动态匹配域名
+## 三：动态匹配域名：
 
 > `www.chromium.org`   ->    `https://`2_www_xn--3px_chromium_xn--3px_org.proxy.domain.com`
 
@@ -68,7 +68,7 @@
 }
 ```
 
-### 阻止指定域名 (拦截请求)
+## 四：阻止指定域名 (拦截请求)
 
 ```json
 
@@ -80,7 +80,7 @@
 
 ```
 
-## manifest host_permissions 例子
+## 五：manifest host_permissions 例子
 ```
 {
     "host_permissions": [ //指定地址写法
@@ -102,7 +102,7 @@
 ```
 
 
-##  本地启动 web server
+##  六：本地启动 web server
 ```shell
 
 sh  extension/test/extension-v3-test/startup-local-test-web-server.sh

--- a/extension/test/extension-v3-test/README.md
+++ b/extension/test/extension-v3-test/README.md
@@ -110,3 +110,5 @@ sh  extension/test/extension-v3-test/startup-local-test-web-server.sh
 ```
 
 
+## 七： 参考文档
+1. [extensions declare_permissions ](https://developer.chrome.com/docs/extensions/mv3/declare_permissions/)


### PR DESCRIPTION
## CHANGELOG for 0.10.5
>1. 新增 `cdn.jsdelivr.net` - 替换为 `fastly.jsdelivr.net`
>2. 新增 `cdnjs.cloudflare.com` - 替换为 `cdnjs.loli.net` 默认未启用
>3. 新增 公共 CDN 静态资源库 极客族公共加速服务 `https://cdn.geekzu.org/cached.html`
>4. 新增 公共 CDN 静态资源库 七牛静态库 `http://staticfile.org/`
>5. 新增 通过国内镜像 克隆本项目源代码