### PR TITLE
修改4个域名重定向规则

### DIFF
--- a/CHANGELOG-v3-0.10.x.md
+++ b/CHANGELOG-v3-0.10.x.md
@@ -4,6 +4,12 @@
 
 ## [一个完整的 测试环境例子 可用于查看优秀的源码 ](https://github.com/jingjingxyk/extension-v3-test)
 
+## CHANGELOG for v3 0.10.28 [2023-04-12 15:38:00 +0800]
+
+> 1.  域名`lh3.googleusercontent.com` 和 `imgur.com` 添加辅助规则。 删除请求头中 `referer` 键值对
+> 1.  域名`lh3.googleusercontent.com` 和 `imgur.com` 重定向规则 资源类型，仅限图片
+> 1.  域名`fonts.googleapis.com` 和 `fonts.googleapis.com` 修改重定向规则,修改重定向到的目标地址
+
 ## CHANGELOG for v3 0.10.27 [2023-04-02 21:50:00 +0800]
 
 > 1.  v3 版本 修复 通过重新组织代码，解决删除单条规则时,重复渲染动态规则列表的 bug

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -37,6 +37,11 @@
         "id": "ruleset_domain_replace",
         "enabled": false,
         "path": "rules/rules_domain_replace.json"
+      },
+      {
+        "id": "ruleset_default_domains_helper",
+        "enabled": true,
+        "path": "rules/rules-default-domains-helper.json"
       }
     ]
   },

--- a/extension/rules/mirrors/imgur.com.json
+++ b/extension/rules/mirrors/imgur.com.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 1,
-    "priority": 200,
+    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {
@@ -22,7 +22,7 @@
   },
   {
     "id": 2,
-    "priority": 100,
+    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {
@@ -43,7 +43,7 @@
   },
   {
     "id": 4,
-    "priority": 100,
+    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {
@@ -64,7 +64,7 @@
   },
   {
     "id": 5,
-    "priority": 100,
+    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {

--- a/extension/rules/mirrors/imgur.com.json
+++ b/extension/rules/mirrors/imgur.com.json
@@ -14,19 +14,30 @@
       "resourceTypes": [
         "main_frame",
         "sub_frame",
-        "stylesheet",
-        "script",
         "image",
-        "font",
         "object",
-        "xmlhttprequest",
-        "ping",
-        "csp_report",
-        "media",
-        "websocket",
-        "webtransport",
-        "webbundle",
-        "other"
+        "xmlhttprequest"
+      ]
+    }
+  },
+  {
+    "id": 2,
+    "priority": 100,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "regexSubstitution": "https://img.noobzone.ru/getimg.php?url=\\2"
+      }
+    },
+    "condition": {
+      "regexFilter": "(http[s]{0,1}://)(.*?)",
+      "requestDomains": ["imgur.com"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "image",
+        "object",
+        "xmlhttprequest"
       ]
     }
   },
@@ -45,23 +56,12 @@
       "resourceTypes": [
         "main_frame",
         "sub_frame",
-        "stylesheet",
-        "script",
         "image",
-        "font",
         "object",
-        "xmlhttprequest",
-        "ping",
-        "csp_report",
-        "media",
-        "websocket",
-        "webtransport",
-        "webbundle",
-        "other"
+        "xmlhttprequest"
       ]
     }
   },
-
   {
     "id": 5,
     "priority": 100,
@@ -77,19 +77,9 @@
       "resourceTypes": [
         "main_frame",
         "sub_frame",
-        "stylesheet",
-        "script",
         "image",
-        "font",
         "object",
-        "xmlhttprequest",
-        "ping",
-        "csp_report",
-        "media",
-        "websocket",
-        "webtransport",
-        "webbundle",
-        "other"
+        "xmlhttprequest"
       ]
     }
   }

--- a/extension/rules/mirrors/lh3.googleusercontent.com.json
+++ b/extension/rules/mirrors/lh3.googleusercontent.com.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 1,
-    "priority": 200,
+    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {
@@ -11,29 +11,39 @@
     "condition": {
       "regexFilter": "(.*?)",
       "requestDomains": ["lh3.googleusercontent.com"],
-      "initiatorDomains": ["material.io"],
       "resourceTypes": [
         "main_frame",
         "sub_frame",
-        "stylesheet",
-        "script",
         "image",
-        "font",
         "object",
-        "xmlhttprequest",
-        "ping",
-        "csp_report",
-        "media",
-        "websocket",
-        "webtransport",
-        "webbundle",
-        "other"
+        "xmlhttprequest"
       ]
     }
   },
   {
-    "id": 4,
-    "priority": 100,
+    "id": 2,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "regexSubstitution": "https://img.noobzone.ru/getimg.php?url=\\2"
+      }
+    },
+    "condition": {
+      "regexFilter": "(http[s]{0,1}://)(.*?)",
+      "requestDomains": ["lh3.googleusercontent.com"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "image",
+        "object",
+        "xmlhttprequest"
+      ]
+    }
+  },
+  {
+    "id": 3,
+    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {
@@ -43,30 +53,19 @@
     "condition": {
       "regexFilter": "(http[s]{0,1}://)(.*?)",
       "requestDomains": ["lh3.googleusercontent.com"],
-      "initiatorDomains": ["material.io"],
       "resourceTypes": [
         "main_frame",
         "sub_frame",
-        "stylesheet",
-        "script",
         "image",
-        "font",
         "object",
-        "xmlhttprequest",
-        "ping",
-        "csp_report",
-        "media",
-        "websocket",
-        "webtransport",
-        "webbundle",
-        "other"
+        "xmlhttprequest"
       ]
     }
   },
 
   {
-    "id": 5,
-    "priority": 100,
+    "id": 4,
+    "priority": 1,
     "action": {
       "type": "redirect",
       "redirect": {
@@ -76,23 +75,12 @@
     "condition": {
       "regexFilter": "(.*?)",
       "requestDomains": ["lh3.googleusercontent.com"],
-      "initiatorDomains": ["material.io"],
       "resourceTypes": [
         "main_frame",
         "sub_frame",
-        "stylesheet",
-        "script",
         "image",
-        "font",
         "object",
-        "xmlhttprequest",
-        "ping",
-        "csp_report",
-        "media",
-        "websocket",
-        "webtransport",
-        "webbundle",
-        "other"
+        "xmlhttprequest"
       ]
     }
   }

--- a/extension/rules/rules-default-domains-helper.json
+++ b/extension/rules/rules-default-domains-helper.json
@@ -20,12 +20,12 @@
       ],
       "urlFilter": "https://pic1.xuehuaimg.com/proxy/"
     },
-    "id": 20001,
-    "priority": 100
+    "id": 1,
+    "priority": 1
   },
   {
-    "id": 3,
-    "priority": 100,
+    "id": 2,
+    "priority": 1,
     "action": {
       "type": "modifyHeaders",
       "requestHeaders": [

--- a/extension/rules/rules-default-domains-helper.json
+++ b/extension/rules/rules-default-domains-helper.json
@@ -1,0 +1,50 @@
+[
+  {
+    "action": {
+      "requestHeaders": [
+        {
+          "header": "referer",
+          "operation": "remove"
+        }
+      ],
+      "type": "modifyHeaders"
+    },
+    "condition": {
+      "requestDomains": ["pic1.xuehuaimg.com"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "image",
+        "object",
+        "xmlhttprequest"
+      ],
+      "urlFilter": "https://pic1.xuehuaimg.com/proxy/"
+    },
+    "id": 20001,
+    "priority": 100
+  },
+  {
+    "id": 3,
+    "priority": 100,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        {
+          "header": "referer",
+          "operation": "remove"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "img.noobzone.ru/getimg.php",
+      "requestDomains": ["img.noobzone.ru"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "image",
+        "object",
+        "xmlhttprequest"
+      ]
+    }
+  }
+]

--- a/extension/rules/rules_redirect_main.json
+++ b/extension/rules/rules_redirect_main.json
@@ -48,7 +48,6 @@
     "condition": {
       "urlFilter": "fonts.googleapis.com",
       "requestDomains": ["fonts.googleapis.com"],
-      "excludedRequestDomains": ["fonts.googleapis.com"],
       "resourceTypes": [
         "main_frame",
         "sub_frame",
@@ -116,8 +115,7 @@
     },
     "condition": {
       "urlFilter": "fonts.gstatic.com",
-      "requestDomains": ["fonts.gstatic.com"],
-      "excludedRequestDomains": ["fonts.gstatic.com"],
+      "requestDomains": ["fonts.googleapis.com"],
       "resourceTypes": [
         "main_frame",
         "sub_frame",

--- a/extension/third_party/josdejong/svelte-jsoneditor/main/CHANGELOG.md
+++ b/extension/third_party/josdejong/svelte-jsoneditor/main/CHANGELOG.md
@@ -555,14 +555,14 @@ and some TypeScript types now come from `immutable-json-patch`.
 
 ### Bug Fixes
 
-* indexRouter.js files containing broken imports to ts files ([0c4a9f0](https://github.com/josdejong/svelte-jsoneditor/commit/0c4a9f0c2dea2a45aa5dd5b2176ad7802a4e5206))
+* index.js files containing broken imports to ts files ([0c4a9f0](https://github.com/josdejong/svelte-jsoneditor/commit/0c4a9f0c2dea2a45aa5dd5b2176ad7802a4e5206))
 
 ### [0.3.52](https://github.com/josdejong/svelte-jsoneditor/compare/v0.3.51...v0.3.52) (2022-05-23)
 
 
 ### Bug Fixes
 
-* indexRouter.js file containing broken references to .ts files (regression since v0.3.51) ([36959ee](https://github.com/josdejong/svelte-jsoneditor/commit/36959ee0e2ea8cbbefcbb63f193d83b556404dbc))
+* index.js file containing broken references to .ts files (regression since v0.3.51) ([36959ee](https://github.com/josdejong/svelte-jsoneditor/commit/36959ee0e2ea8cbbefcbb63f193d83b556404dbc))
 
 ### [0.3.51](https://github.com/josdejong/svelte-jsoneditor/compare/v0.3.50...v0.3.51) (2022-05-23)
 

--- a/extension/third_party/josdejong/svelte-jsoneditor/main/CHANGELOG.md
+++ b/extension/third_party/josdejong/svelte-jsoneditor/main/CHANGELOG.md
@@ -555,14 +555,14 @@ and some TypeScript types now come from `immutable-json-patch`.
 
 ### Bug Fixes
 
-* index.js files containing broken imports to ts files ([0c4a9f0](https://github.com/josdejong/svelte-jsoneditor/commit/0c4a9f0c2dea2a45aa5dd5b2176ad7802a4e5206))
+* indexRouter.js files containing broken imports to ts files ([0c4a9f0](https://github.com/josdejong/svelte-jsoneditor/commit/0c4a9f0c2dea2a45aa5dd5b2176ad7802a4e5206))
 
 ### [0.3.52](https://github.com/josdejong/svelte-jsoneditor/compare/v0.3.51...v0.3.52) (2022-05-23)
 
 
 ### Bug Fixes
 
-* index.js file containing broken references to .ts files (regression since v0.3.51) ([36959ee](https://github.com/josdejong/svelte-jsoneditor/commit/36959ee0e2ea8cbbefcbb63f193d83b556404dbc))
+* indexRouter.js file containing broken references to .ts files (regression since v0.3.51) ([36959ee](https://github.com/josdejong/svelte-jsoneditor/commit/36959ee0e2ea8cbbefcbb63f193d83b556404dbc))
 
 ### [0.3.51](https://github.com/josdejong/svelte-jsoneditor/compare/v0.3.50...v0.3.51) (2022-05-23)
 


### PR DESCRIPTION
修改4个域名重定向规则
解锁： `lh3.googleusercontent.com` 和 `imgur.com` 域名重定向 使用限制，虽然解除了限制，默认仍然保持不启用