### PR TITLE
Add optional unsafe CDN redirect example

### DIFF
--- a/extension/options_ui/advance.html
+++ b/extension/options_ui/advance.html
@@ -157,6 +157,9 @@
                         <button data-rule="block-domain">
                             例子：屏蔽指定域名(jingjingxyk.com)
                         </button>
+                        <button data-rule="unsafe-cdn-redirect">
+                            例子：替换不安全 CDN
+                        </button>
                         <button data-rule="modify-header-ua">
                             例子：请求头修改 UserAgent
                         </button>

--- a/extension/options_ui/js/AdvanceBundle/Config/rule_example_conf.js
+++ b/extension/options_ui/js/AdvanceBundle/Config/rule_example_conf.js
@@ -1,6 +1,7 @@
 let rule_example = {
   "redirect-domain": `redirect-domain.json`,
   "block-domain": `block-domain.json`,
+  "unsafe-cdn-redirect": `unsafe-cdn-redirect.json`,
   "modify-header-ua": `rules_modify_request_header_ua.json`,
   "modify-header-request-x": `rules_modify_request_header_x.json`,
   "modify-header-request-cookie": `rules_modify_request_header_cookie.json`,

--- a/extension/options_ui/rule_example/unsafe-cdn-redirect.json
+++ b/extension/options_ui/rule_example/unsafe-cdn-redirect.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": 1,
+    "priority": 1000,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "regexSubstitution": "https://fastly.jsdelivr.net/npm/\\1@\\2/dist/\\3"
+      }
+    },
+    "condition": {
+      "regexFilter": "^https?://(?:cdn\\.bootcss\\.com|cdn\\.bootcdn\\.net|cdn\\.staticfile\\.net|cdn\\.staticfile\\.org)/ajax/libs/(.*?)/(.*?)/(.*?)",
+      "requestDomains": [
+        "cdn.bootcss.com",
+        "cdn.bootcdn.net",
+        "cdn.staticfile.net",
+        "cdn.staticfile.org"
+      ],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "webtransport",
+        "webbundle",
+        "other"
+      ]
+    }
+  }
+]

--- a/public-cdn.md
+++ b/public-cdn.md
@@ -11,6 +11,7 @@
 1. [google libraries cn](https://developers.google.cn/speed/libraries)
 1. [CDNJS 南方科技大学](https://mirrors.sustech.edu.cn/help/cdnjs.html)
 1. [CDNJS mirror list ](https://mirrorz.org/list/cdnjs)
+1. [Webcache.cn](https://www.webcache.cn/)
 1. [公共 CDN 静态资源加速服务 7ED Services (use.sevencdn.com )](https://www.7ed.net/start/public-cdn.html)
 1. [中科大反向代理列表如下：](https://mirrors.ustc.edu.cn/)
 


### PR DESCRIPTION
## Summary
- Add Webcache.cn to the public CDN candidate list for #206.
- Add an optional unsafe CDN redirect example for #219 without changing default enabled rules.
- Wire the example into the advanced options autofill list.

## Validation
- Parsed repository JSON files with Node: json ok 51.

## Notes
- Did not change default static rules because replacing or blocking the reported CDN domains globally could affect existing sites.
- release-archive-v3.sh was attempted locally but could not complete because this environment does not have zip installed.