### PR TITLE
Fix repeated rule list event binding

### DIFF
--- a/extension/options_ui/js/CommonBundle/Components/showRuleList.js
+++ b/extension/options_ui/js/CommonBundle/Components/showRuleList.js
@@ -11,6 +11,7 @@ import {
 } from "./showStaticRules.js";
 
 let timeoutHandler = null;
+let isRuleListEventBound = false;
 
 let bindButtonEventListener = () => {
   //备份单条规则
@@ -103,14 +104,18 @@ let showRuleList = (type) => {
 
   //显示静态规则
   showStaticRules();
-  bindStaticRuleEventListener();
 
   //显示动态规则
   showDynamicRules(type);
-  bindDynamicRuleEventListener();
 
-  //选项四：已启用规则列表： 绑定按钮
-  bindButtonEventListener();
+  if (!isRuleListEventBound) {
+    bindStaticRuleEventListener();
+    bindDynamicRuleEventListener();
+
+    //选项四：已启用规则列表： 绑定按钮
+    bindButtonEventListener();
+    isRuleListEventBound = true;
+  }
 };
 
 export default showRuleList;


### PR DESCRIPTION
## Summary
- Prevent `showRuleList()` from rebinding rule list and action button event listeners on every refresh.
- Keep static and dynamic rule rendering refreshable while binding DOM events only once per options page lifecycle.

## Validation
- `node --check` for all non-third-party extension JavaScript files
- `git diff --check`
- `npx --yes prettier@3.5.3 --check extension/options_ui/js/CommonBundle/Components/showRuleList.js`

Fixes #224