### PR TITLE
Fix high priority override rule matching

### DIFF
--- a/extension/rules/mirrors/supper-priority-override.json
+++ b/extension/rules/mirrors/supper-priority-override.json
@@ -16,12 +16,6 @@
         "developer.android.com",
         "www.google.com"
       ],
-      "excludedRequestDomains": [
-        "developers.google.com",
-        "source.android.com",
-        "developer.android.com",
-        "www.google.com"
-      ],
       "resourceTypes": [
         "main_frame",
         "sub_frame",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "fmt": "prettier --write \"extension/**/*.{ts,js}\"",
     "fmt:check": "prettier --check \"extension/**/*.{ts,js}\"",
     "format-code": "npx prettier --write . ",
+    "rules:check": "node test/check-rules.js",
     "release": "bash release-archive.sh",
     "firefox-test": "bash tools/firefox-web-ext.sh",
     "chromium-test": "bash tools/chromium.sh"

--- a/test/check-rules.js
+++ b/test/check-rules.js
@@ -1,0 +1,81 @@
+const fs = require("fs");
+const path = require("path");
+
+const ruleDirectories = [
+  path.join("extension", "rules"),
+  path.join("extension", "options_ui", "rule_example")
+];
+
+const errors = [];
+
+function walkJsonFiles(directory) {
+  const files = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const filePath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...walkJsonFiles(filePath));
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      files.push(filePath);
+    }
+  }
+
+  return files;
+}
+
+function findOverlap(left = [], right = []) {
+  const rightSet = new Set(right);
+  return left.filter((value) => rightSet.has(value));
+}
+
+function checkDomainCondition(filePath, rule, includeKey, excludeKey) {
+  const condition = rule.condition || {};
+  const overlap = findOverlap(condition[includeKey], condition[excludeKey]);
+
+  if (overlap.length > 0) {
+    errors.push(
+      `${filePath}: rule ${rule.id} contains the same domain in ${includeKey} and ${excludeKey}: ${overlap.join(", ")}`
+    );
+  }
+}
+
+function checkUrlFilters(filePath, rule) {
+  const condition = rule.condition || {};
+
+  if (condition.urlFilter && condition.regexFilter) {
+    errors.push(
+      `${filePath}: rule ${rule.id} specifies both urlFilter and regexFilter`
+    );
+  }
+}
+
+for (const directory of ruleDirectories) {
+  for (const filePath of walkJsonFiles(directory)) {
+    const rules = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    const ruleList = Array.isArray(rules) ? rules : [rules];
+
+    for (const rule of ruleList) {
+      checkDomainCondition(
+        filePath,
+        rule,
+        "requestDomains",
+        "excludedRequestDomains"
+      );
+      checkDomainCondition(
+        filePath,
+        rule,
+        "initiatorDomains",
+        "excludedInitiatorDomains"
+      );
+      checkUrlFilters(filePath, rule);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+
+console.log("Rule checks passed.");


### PR DESCRIPTION
## Summary
- Remove the duplicate `excludedRequestDomains` from `supper-priority-override.json`; the same domains were also listed in `requestDomains`, so the high-priority override rule could never match.
- Add `npm run rules:check` to catch rules that include and exclude the same domain, or specify both `urlFilter` and `regexFilter`.

## Validation
- `npm run rules:check`
- `node --check test/check-rules.js`
- `node --check` for all non-third-party extension/test JavaScript files
- `git diff --check`
- `npx --yes prettier@3.5.3 --check package.json test/check-rules.js extension/rules/mirrors/supper-priority-override.json`