### PR TITLE
Fix v3 manifest browser selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tools/web/proxy.pac
 dist
 var
 runtime
+__pycache__/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "fmt": "prettier --write \"extension/**/*.{ts,js}\"",
     "fmt:check": "prettier --check \"extension/**/*.{ts,js}\"",
     "format-code": "npx prettier --write . ",
+    "manifest:check": "python test/check-v3-manifest.py",
     "rules:check": "node test/check-rules.js",
     "release": "bash release-archive.sh",
     "firefox-test": "bash tools/firefox-web-ext.sh",

--- a/test/check-v3-manifest.py
+++ b/test/check-v3-manifest.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+project_dir = Path(__file__).resolve().parents[1]
+manifest_file = project_dir / "var" / "extension-tmp" / "manifest.json"
+script_file = project_dir / "tools" / "update-v3-manifest.py"
+
+
+def generate_manifest(browser):
+    subprocess.run(
+        [sys.executable, str(script_file), browser],
+        cwd=project_dir,
+        check=True,
+    )
+    return json.loads(manifest_file.read_text(encoding="utf-8"))
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+chromium_manifest = generate_manifest("chromium")
+require(
+    chromium_manifest.get("background", {}).get("service_worker")
+    == "js/background.js",
+    "chromium manifest must use background.service_worker",
+)
+require(
+    "browser_specific_settings" not in chromium_manifest,
+    "chromium manifest must not include gecko settings",
+)
+require("options_ui" in chromium_manifest, "chromium manifest must keep options_ui")
+require("sandbox" in chromium_manifest, "chromium manifest must keep sandbox")
+
+firefox_manifest = generate_manifest("firefox")
+require(
+    firefox_manifest.get("background", {}).get("page") == "background-page.html",
+    "firefox manifest must use background.page",
+)
+require(
+    "browser_specific_settings" in firefox_manifest,
+    "firefox manifest must include gecko settings",
+)
+require("options_ui" not in firefox_manifest, "firefox manifest must remove options_ui")
+require("sandbox" not in firefox_manifest, "firefox manifest must remove sandbox")
+
+print("Manifest checks passed.")

--- a/tools/update-v3-manifest.py
+++ b/tools/update-v3-manifest.py
@@ -29,7 +29,7 @@ def set_manifest_data(manifest, key, value):
 
 def override_manifest(manifest):
     os.makedirs(extension_tmp_dir, exist_ok=True)
-    with open(manifest_tmp_file, mode='w') as f:
+    with open(manifest_tmp_file, mode='w', encoding='utf-8') as f:
         json.dump(manifest, f, ensure_ascii=False, indent=2)
 
 
@@ -56,8 +56,11 @@ if __name__ == '__main__':
     if browser == '--help' or browser == '-h':
         print(comment)
         exit(0)
-    else:
-        browser = 'firefox'
+
+    if browser not in ('chromium', 'firefox'):
+        print('unsupported browser: ' + browser)
+        print(comment)
+        exit(2)
 
     # chromium config
     chromium_background_content = '''
@@ -116,5 +119,6 @@ if __name__ == '__main__':
     manifest_data = set_manifest_data(manifest_data, 'sandbox', sandbox_content)
     manifest_data = set_manifest_data(manifest_data, 'content_security_policy', content_security_policy_sandbox_content)
     manifest_data = set_manifest_data(manifest_data, 'browser_specific_settings', browser_specific_settings)
-    manifest_data = set_manifest_data(manifest_data, 'options_ui', '')
+    if browser == 'firefox':
+        manifest_data = set_manifest_data(manifest_data, 'options_ui', '')
     override_manifest(manifest_data)


### PR DESCRIPTION
## Summary
- Fix `tools/update-v3-manifest.py chromium` being forced through the Firefox manifest path.
- Keep `options_ui` in generated Chromium manifests and only remove it for Firefox manifests.
- Write generated manifests as UTF-8 so Windows builds do not produce non-UTF-8 JSON.
- Add `npm run manifest:check` to validate Chromium and Firefox manifest outputs.

## Validation
- `npm run manifest:check`
- `npm run rules:check`
- `python -m py_compile tools/update-v3-manifest.py test/check-v3-manifest.py`
- `node --check` for all non-third-party extension/test JavaScript files
- `git diff --check`
- `npx --yes prettier@3.5.3 --check package.json test/check-rules.js`

Note: `bash release-archive-v3.sh` could not run fully in this environment because `zip` is not installed.