### PR TITLE
Fix Firefox manifest rule resources

### DIFF
--- a/test/check-v3-manifest.py
+++ b/test/check-v3-manifest.py
@@ -37,6 +37,10 @@ require("options_ui" in chromium_manifest, "chromium manifest must keep options_
 require("sandbox" in chromium_manifest, "chromium manifest must keep sandbox")
 
 firefox_manifest = generate_manifest("firefox")
+firefox_rule_paths = {
+    rule["path"]
+    for rule in firefox_manifest["declarative_net_request"]["rule_resources"]
+}
 require(
     firefox_manifest.get("background", {}).get("page") == "background-page.html",
     "firefox manifest must use background.page",
@@ -47,5 +51,9 @@ require(
 )
 require("options_ui" not in firefox_manifest, "firefox manifest must remove options_ui")
 require("sandbox" not in firefox_manifest, "firefox manifest must remove sandbox")
+require(
+    "rules/rules-default-domains-helper.json" not in firefox_rule_paths,
+    "firefox manifest must not reference rules-default-domains-helper.json",
+)
 
 print("Manifest checks passed.")

--- a/tools/update-v3-manifest.py
+++ b/tools/update-v3-manifest.py
@@ -33,6 +33,16 @@ def override_manifest(manifest):
         json.dump(manifest, f, ensure_ascii=False, indent=2)
 
 
+def remove_rule_resources(manifest, paths):
+    rule_resources = manifest.get('declarative_net_request', {}).get('rule_resources', [])
+    manifest['declarative_net_request']['rule_resources'] = [
+        rule_resource
+        for rule_resource in rule_resources
+        if rule_resource.get('path') not in paths
+    ]
+    return manifest
+
+
 if __name__ == '__main__':
     comment = '''
       用法：python3 tools/update-v3-manifest.py [ chromium | firefox ]
@@ -121,4 +131,10 @@ if __name__ == '__main__':
     manifest_data = set_manifest_data(manifest_data, 'browser_specific_settings', browser_specific_settings)
     if browser == 'firefox':
         manifest_data = set_manifest_data(manifest_data, 'options_ui', '')
+        manifest_data = remove_rule_resources(
+            manifest_data,
+            {
+                'rules/rules-default-domains-helper.json',
+            }
+        )
     override_manifest(manifest_data)


### PR DESCRIPTION
## Summary
- Remove `rules/rules-default-domains-helper.json` from generated Firefox manifest rule resources.
- Keep the existing Firefox release behavior that excludes that helper rule file from the package, but make the manifest match the packaged files.
- Extend `manifest:check` to catch this missing packaged rule reference.

## Validation
- `npm run manifest:check`
- `npm run rules:check`
- `python -m py_compile tools/update-v3-manifest.py test/check-v3-manifest.py`
- `node --check` for all non-third-party extension/test JavaScript files
- `git diff --check`

Note: full `release-archive-v3.sh` still cannot run in this environment because `zip` is not installed.