### PR TITLE
Fix Chromium mirror venv setup

### DIFF
--- a/tools/download-chromium.sh
+++ b/tools/download-chromium.sh
@@ -71,8 +71,8 @@ if [ -z "$WITH_MIRROR" ]; then
 else
   if [ "$WITH_MIRROR" = 'china' ]; then
     # 默认来源于 https://registry.npmmirror.com/-/binary/chromium-browser-snapshots/
-    test -d ${__PROJECT__}/var/venv || bash ${__PROJECT__}/tools/python3-env-init.sh
-    . venv/bin/activate
+    test -d ${__PROJECT__}/var/.venv || bash ${__PROJECT__}/tools/python3-venv-install.sh
+    . ${__PROJECT__}/var/.venv/bin/activate
     cd ${__DIR__}
     case $OS in
     "Linux")


### PR DESCRIPTION
Fixes the Chromium mirror download path so it uses the existing Python venv installer and activates var/.venv. Verified with bash syntax checks, py_compile, and existing npm checks.