### PR TITLE
Handle DNR update failures

### DIFF
--- a/extension/options_ui/js/AdvanceBundle/Components/globalDynamicRuleMain.js
+++ b/extension/options_ui/js/AdvanceBundle/Components/globalDynamicRuleMain.js
@@ -4,7 +4,8 @@ import {
   backupSelfDefinedDynamicRules,
   utils,
   enableStaticRules,
-  id_ranges
+  id_ranges,
+  logChromeRuntimeError
 } from "../../CommonBundle/Components/common.js";
 import { remote_repository_static_urls } from "../Config/rule_example_conf.js";
 import showRuleList from "../../CommonBundle/Components/showRuleList.js";
@@ -95,7 +96,11 @@ let bindSyncRemoteStaticRuleEventListener = () => {
 
           chrome.declarativeNetRequest.updateEnabledRulesets(
             UpdateRulesetOptions,
-            (callback) => {
+            () => {
+              if (logChromeRuntimeError("updateEnabledRulesets")) {
+                return;
+              }
+
               showRuleList();
             }
           );

--- a/extension/options_ui/js/CommonBundle/Components/common.js
+++ b/extension/options_ui/js/CommonBundle/Components/common.js
@@ -27,6 +27,16 @@ let rule_action_type_map = {
   block: "阻止请求"
 };
 
+let logChromeRuntimeError = (operation) => {
+  let error = chrome.runtime.lastError;
+  if (!error) {
+    return false;
+  }
+
+  console.error(operation + " failed: " + error.message);
+  return true;
+};
+
 let updateDynamicRules = (
   addRules = [],
   removeRuleIds = [],
@@ -39,7 +49,11 @@ let updateDynamicRules = (
       removeRuleIds: removeRuleIds
     },
     () => {
-      callback(args);
+      if (logChromeRuntimeError("updateDynamicRules")) {
+        return;
+      }
+
+      callback(...args);
     }
   );
 };
@@ -83,7 +97,11 @@ let deleteDynamicRules = (type, id = 0, callback = () => {}, ...args) => {
           removeRuleIds: del_ids
         },
         () => {
-          callback(args);
+          if (logChromeRuntimeError("deleteDynamicRules")) {
+            return;
+          }
+
+          callback(...args);
         }
       );
     }
@@ -147,6 +165,10 @@ let enableStaticRules = (callback, ...args) => {
   chrome.declarativeNetRequest.updateEnabledRulesets(
     updateRulesetOptions,
     () => {
+      if (logChromeRuntimeError("updateEnabledRulesets")) {
+        return;
+      }
+
       deleteDynamicRules("sync_remote_static_rule", 0, () => {
         callback();
       });
@@ -162,5 +184,6 @@ export {
   id_ranges,
   id_range_name_map,
   rule_action_type_map,
-  enableStaticRules
+  enableStaticRules,
+  logChromeRuntimeError
 };


### PR DESCRIPTION
Checks chrome.runtime.lastError after dynamic rule and ruleset updates so failure paths stop instead of running success callbacks. Verified with JS syntax checks, git diff checks, and existing npm checks.