### PR TITLE
Download arm Chromium on macOS arm64

### DIFF
--- a/tools/download-chromium.sh
+++ b/tools/download-chromium.sh
@@ -56,10 +56,14 @@ if [ -z "$WITH_MIRROR" ]; then
     DOWNLOAD_CHROMIUM_URL="https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/$REVISION/chrome-linux.zip"
     ;;
   "Darwin")
-    LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac%2FLAST_CHANGE?alt=media"
+    CHROMIUM_SNAPSHOT_PLATFORM="Mac"
+    if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
+      CHROMIUM_SNAPSHOT_PLATFORM="Mac_Arm"
+    fi
+    LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/${CHROMIUM_SNAPSHOT_PLATFORM}%2FLAST_CHANGE?alt=media"
     REVISION=$(curl -s -S $LASTCHANGE_URL)
     echo "latest revision is $REVISION"
-    DOWNLOAD_CHROMIUM_URL="https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/$REVISION/chrome-mac.zip"
+    DOWNLOAD_CHROMIUM_URL="https://commondatastorage.googleapis.com/chromium-browser-snapshots/${CHROMIUM_SNAPSHOT_PLATFORM}/$REVISION/chrome-mac.zip"
     ;;
   'MINGW64_NT'* | 'MSYS_NT'*)
     LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Win_x64%2FLAST_CHANGE?alt=media"
@@ -79,7 +83,11 @@ else
       DOWNLOAD_CHROMIUM_URL=$(python3 get-latest-chromium-version-main.py linux)
       ;;
     "Darwin")
-      DOWNLOAD_CHROMIUM_URL=$(python3 get-latest-chromium-version-main.py darwin)
+      if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
+        DOWNLOAD_CHROMIUM_URL=$(python3 get-latest-chromium-version-main.py darwin-arm64)
+      else
+        DOWNLOAD_CHROMIUM_URL=$(python3 get-latest-chromium-version-main.py darwin)
+      fi
       ;;
     *)
       DOWNLOAD_CHROMIUM_URL=$(python3 get-latest-chromium-version-main.py win)

--- a/tools/get-latest-chromium-version-main.py
+++ b/tools/get-latest-chromium-version-main.py
@@ -21,7 +21,8 @@ if __name__ == '__main__':
      例子：
      python3 get-latest-chromium-version-main.py  linux
      python3 get-latest-chromium-version-main.py  win 
-     python3 get-latest-chromium-version-main.py  darwin 
+     python3 get-latest-chromium-version-main.py  darwin
+     python3 get-latest-chromium-version-main.py  darwin-arm64
     '''
 
     os = platform.system()
@@ -34,6 +35,8 @@ if __name__ == '__main__':
         os_platform = "Linux_x64"
     elif os == "darwin" or os == "Darwin":
         os_platform = "Mac"
+    elif os in ("darwin-arm64", "Darwin-arm64", "darwin-aarch64", "mac-arm64", "Mac_Arm"):
+        os_platform = "Mac_Arm"
     elif os == "win" or os == "Windows":
         os_platform = "Win_x64"
     elif os == "-h" or os == "--h":


### PR DESCRIPTION
Uses the Mac_Arm Chromium snapshot bucket when uname reports Darwin arm64 or aarch64, including the mirror helper path. Verified with bash syntax, py_compile, a Darwin arm64 stub run, Mac_Arm mirror URL lookup, and existing npm checks.