### PR TITLE
Fix Linux Firefox cache path

### DIFF
--- a/.github/workflows/linux-aarch64.yaml
+++ b/.github/workflows/linux-aarch64.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ github.workspace }}/var/firefox.tar.bz2
+            ${{ github.workspace }}/var/firefox.tar
             ${{ github.workspace }}/var/firefox/
           key: ${{ runner.os }}-x86_64-firefox
 
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          if [ ! -f ${{ github.workspace }}/var/firefox.tar.bz2 ] ; then
+          if [ ! -f ${{ github.workspace }}/var/firefox.tar ] ; then
             bash tools/download-firefox.sh
           fi
 

--- a/.github/workflows/linux-x86_64.yaml
+++ b/.github/workflows/linux-x86_64.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ github.workspace }}/var/firefox.tar.bz2
+            ${{ github.workspace }}/var/firefox.tar
             ${{ github.workspace }}/var/firefox/
           key: ${{ runner.os }}-x86_64-firefox
 
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          if [ ! -f ${{ github.workspace }}/var/firefox.tar.bz2 ] ; then
+          if [ ! -f ${{ github.workspace }}/var/firefox.tar ] ; then
             bash tools/download-firefox.sh
           fi
 


### PR DESCRIPTION
Updates Linux workflows to cache and check var/firefox.tar, matching the artifact produced by tools/download-firefox.sh after xz decompression. Verified workflow YAML parsing, bash syntax, path search, and existing npm checks.