### PR TITLE
Fix Linux arm Firefox cache key

### DIFF
--- a/.github/workflows/linux-aarch64.yaml
+++ b/.github/workflows/linux-aarch64.yaml
@@ -86,7 +86,7 @@ jobs:
           path: |
             ${{ github.workspace }}/var/firefox.tar
             ${{ github.workspace }}/var/firefox/
-          key: ${{ runner.os }}-x86_64-firefox
+          key: ${{ runner.os }}-aarch64-firefox
 
       - name: Download Firefox
         shell: bash


### PR DESCRIPTION
Updates the linux-aarch64 Firefox cache key to use aarch64 instead of x86_64. Verified workflow YAML parsing, key search, and git diff checks.