### PR TITLE
Remove stale Firefox tar before download

### DIFF
--- a/tools/download-firefox.sh
+++ b/tools/download-firefox.sh
@@ -62,6 +62,7 @@ DOWNLOAD_FIREFOX_URL_PREFIX=https://archive.mozilla.org/pub/firefox/releases
 case $OS in
 "Linux")
   test -f firefox.tar.xz && rm -rf firefox.tar.xz
+  test -f firefox.tar && rm -rf firefox.tar
   test -d firefox && rm -rf firefox
   DOWNLOAD_FIREFOX_URL=${DOWNLOAD_FIREFOX_URL_PREFIX}/${FIREFOX_VERSION}/linux-${ARCH}/en-US/firefox-${FIREFOX_VERSION}.tar.xz
   curl -Lo firefox.tar.xz ${DOWNLOAD_FIREFOX_URL}


### PR DESCRIPTION
Deletes the decompressed firefox.tar before re-running the Linux Firefox download path, preventing xz from failing when the output tar already exists. Verified with bash syntax, a stubbed stale-tar run, and existing npm checks.