### PR TITLE
Use consistent latest Firefox path on macOS

### DIFF
--- a/tools/download-firefox-latest-stable.sh
+++ b/tools/download-firefox-latest-stable.sh
@@ -55,9 +55,9 @@ case $OS in
   hdiutil attach -mountpoint ${TMP_MOUNT_POINT} firefox.dmg
 
   # 将应用程序拷贝到指定目录
-  mkdir -p ${__PROJECT__}/var/Firefox
-  cp -rf /private/${TMP_MOUNT_POINT}/Firefox.app ${__PROJECT__}/var/Firefox
-  ls -lh ${__PROJECT__}/var/Firefox/
+  mkdir -p ${__PROJECT__}/var/firefox
+  cp -rf /private/${TMP_MOUNT_POINT}/Firefox.app ${__PROJECT__}/var/firefox
+  ls -lh ${__PROJECT__}/var/firefox/
 
   ;;
 


### PR DESCRIPTION
Updates the latest Firefox download helper to place Firefox.app under var/firefox on macOS, matching the other download helper, run scripts, and workflows. Verified with bash syntax, Darwin stub run, path search, and existing npm checks.