### PR TITLE
Fix latest Firefox Linux extraction

### DIFF
--- a/tools/download-firefox-latest-stable.sh
+++ b/tools/download-firefox-latest-stable.sh
@@ -43,8 +43,11 @@ echo "${OS}-${ARCH}"
 
 case $OS in
 "Linux")
-  curl -Lo firefox.tar.bz2 "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US"
-  tar -jxvf firefox.tar.bz2
+  test -f firefox.tar.bz2 && rm -rf firefox.tar.bz2
+  test -f firefox.tar.xz && rm -rf firefox.tar.xz
+  test -d firefox && rm -rf firefox
+  curl -Lo firefox.tar.xz "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US"
+  tar -xJvf firefox.tar.xz
   ;;
 "Darwin")
   curl -Lo firefox.dmg "https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US"


### PR DESCRIPTION
## Summary
- download latest Linux Firefox as firefox.tar.xz
- extract with xz tar mode instead of bzip2
- remove stale Linux Firefox archives before downloading

## Verification
- bash -n tools/download-firefox-latest-stable.sh
- curl -fILsS confirmed latest Linux Firefox redirects to .tar.xz
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check