### PR TITLE
Fix Node runtime setup archives

### DIFF
--- a/tools/npm-init.sh
+++ b/tools/npm-init.sh
@@ -28,7 +28,7 @@ while [ $# -gt 0 ]; do
   shift $(($# > 0 ? 1 : 0))
 done
 
-if [[ ! -f ${__PROJECT__}/runtime/node/bin/node ]]; then
+if [[ ! -f ${__PROJECT__}/runtime/node/bin/node && ! -f ${__PROJECT__}/runtime/node/bin/node.exe ]]; then
   if [[ "$MIRROR" == "china" ]]; then
     bash tools/setup-nodejs-runtime.sh --mirror china
   else

--- a/tools/setup-nodejs-runtime.sh
+++ b/tools/setup-nodejs-runtime.sh
@@ -55,6 +55,16 @@ esac
 APP_VERSION='v22.16.0'
 APP_NAME='node'
 VERSION='v22.16.0'
+APP_ARCHIVE_EXT='tar.xz'
+
+case $OS in
+'darwin')
+  APP_ARCHIVE_EXT='tar.gz'
+  ;;
+'win')
+  APP_ARCHIVE_EXT='zip'
+  ;;
+esac
 
 cd ${__PROJECT__}
 mkdir -p runtime/
@@ -76,11 +86,7 @@ https://nodejs.org/dist/v22.16.0/node-v22.16.0-win-x64.zip
 https://registry.npmmirror.com/-/binary/node/v22.16.0/node-v22.16.0-win-x64.zip
 EOF
 
-APP_DOWNLOAD_URL="https://nodejs.org/dist/${VERSION}/${APP_NAME}-${APP_VERSION}-${OS}-${ARCH}.tar.xz"
-
-if [ $OS = 'win' ]; then
-  APP_DOWNLOAD_URL="https://nodejs.org/dist/${VERSION}/${APP_NAME}-${APP_VERSION}-${OS}-${ARCH}.zip"
-fi
+APP_DOWNLOAD_URL="https://nodejs.org/dist/${VERSION}/${APP_NAME}-${APP_VERSION}-${OS}-${ARCH}.${APP_ARCHIVE_EXT}"
 
 MIRROR=''
 while [ $# -gt 0 ]; do
@@ -105,21 +111,15 @@ done
 
 case "$MIRROR" in
 china)
-  APP_DOWNLOAD_URL="https://registry.npmmirror.com/-/binary/node/${APP_VERSION}/${APP_NAME}-${APP_VERSION}-${OS}-${ARCH}.tar.xz"
-  if [ $OS = 'windows' ]; then
-    APP_DOWNLOAD_URL="https://registry.npmmirror.com/-/binary/node/${APP_VERSION}/${APP_NAME}-${APP_VERSION}-${OS}-${ARCH}.zip"
-  fi
+  APP_DOWNLOAD_URL="https://registry.npmmirror.com/-/binary/node/${APP_VERSION}/${APP_NAME}-${APP_VERSION}-${OS}-${ARCH}.${APP_ARCHIVE_EXT}"
   ;;
 esac
 
 APP_RUNTIME="${APP_NAME}-${APP_VERSION}-${OS}-${ARCH}"
 if [ $OS = 'win' ]; then
-  {
-    test -f ${APP_RUNTIME}.zip || curl -fSLo ${APP_RUNTIME}.zip ${APP_DOWNLOAD_URL}
-    test -d ${APP_RUNTIME} && rm -rf ${APP_RUNTIME}
-    unzip "${APP_RUNTIME}.zip"
-    exit 0
-  }
+  test -f ${APP_RUNTIME}.zip || curl -fSLo ${APP_RUNTIME}.zip ${APP_DOWNLOAD_URL}
+  test -d ${APP_RUNTIME} && rm -rf ${APP_RUNTIME}
+  unzip "${APP_RUNTIME}.zip"
 else
   if [ $OS = "darwin" ]; then
     test -f ${APP_RUNTIME}.tar.gz || curl -fSLo ${APP_RUNTIME}.tar.gz ${APP_DOWNLOAD_URL}
@@ -131,7 +131,13 @@ else
     test -f ${APP_RUNTIME}.tar || xz -d -k ${APP_RUNTIME}.tar.xz
     test -d ${APP_RUNTIME} || tar -xvf ${APP_RUNTIME}.tar
   fi
-  test -d ${APP_RUNTIME_DIR} && rm -rf ${APP_RUNTIME_DIR}
+fi
+
+test -d ${APP_RUNTIME_DIR} && rm -rf ${APP_RUNTIME_DIR}
+if [ $OS = 'win' ]; then
+  mkdir -p ${APP_RUNTIME_DIR}
+  mv ${APP_RUNTIME} ${APP_RUNTIME_DIR}/bin
+else
   mv ${APP_RUNTIME} ${APP_RUNTIME_DIR}
 fi
 


### PR DESCRIPTION
## Summary
- choose the Node archive extension from the normalized platform
- use .tar.gz for macOS and .zip for Windows, including the China mirror
- install Windows Node zip contents under runtime/node/bin so existing PATH setup works
- let npm-init detect node.exe on Windows

## Verification
- mocked tools/setup-nodejs-runtime.sh for MINGW64_NT x86_64 with --mirror china
- mocked tools/setup-nodejs-runtime.sh for Darwin arm64 with --mirror china
- curl -fILsS for nodejs.org macOS arm64 tar.gz
- curl -fILsS for nodejs.org Windows x64 zip
- curl -fILsS for npmmirror macOS arm64 tar.gz
- curl -fILsS for npmmirror Windows x64 zip
- bash -n tools/setup-nodejs-runtime.sh && bash -n tools/npm-init.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check