### PR TITLE
Use portable project paths in tools

### DIFF
--- a/tools/npm-init.sh
+++ b/tools/npm-init.sh
@@ -8,7 +8,10 @@ __DIR__=$(
 )
 cd ${__DIR__}
 
-__PROJECT__=$(readlink -f ${__DIR__}/../)
+__PROJECT__=$(
+  cd ${__DIR__}/../
+  pwd
+)
 
 cd ${__PROJECT__}
 

--- a/tools/web-server.sh
+++ b/tools/web-server.sh
@@ -6,7 +6,10 @@ __DIR__=$(
   pwd
 )
 
-__PROJECT__=$(readlink -f ${__DIR__}/../)
+__PROJECT__=$(
+  cd ${__DIR__}/../
+  pwd
+)
 echo ${__PROJECT__}
 
 cd ${__PROJECT__}/tools/web/


### PR DESCRIPTION
﻿## Summary
- replace GNU-specific readlink -f project root resolution in npm-init.sh
- replace GNU-specific readlink -f project root resolution in web-server.sh
- match the cd dirname; pwd pattern already used by the other tool scripts

## Verification
- bash -n tools/npm-init.sh and bash -n tools/web-server.sh
- rg readlink -f tools returns no matches
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
