### PR TITLE
Fix Chromium Windows OS matching

### DIFF
--- a/tools/chromium.sh
+++ b/tools/chromium.sh
@@ -52,7 +52,8 @@ case $OS in
   UUID=$(uuidgen)
   CHROMIUM='chrome-mac/Chromium.app/Contents/MacOS/Chromium'
   ;;
-"MINGW64_NT")
+'MINGW64_NT'* | 'MSYS_NT'*)
+  UUID=$(uuidgen)
   # set chrome_user_data_dir='C:\Users\%username%\Local" "Settings\Temp\chrome-user-data'
   # IF NOT EXIST %chrome_user_data_dir%  MD %chrome_user_data_dir%
   CHROMIUM='chrome-win/chrome.exe'


### PR DESCRIPTION
﻿## Summary
- match MINGW64_NT-* and MSYS_NT-* in tools/chromium.sh
- create a UUID-backed user data directory for the Windows branch
- keep the Chrome executable path consistent with download-chromium.sh

## Verification
- mocked tools/chromium.sh with uname -s = MINGW64_NT-10.0 and fake chrome.exe
- bash -n tools/chromium.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
