### PR TITLE
Fix Chromium extension download directory

### DIFF
--- a/tools/download-chromium-extension.sh
+++ b/tools/download-chromium-extension.sh
@@ -43,7 +43,7 @@ while [ $# -gt 0 ]; do
   shift $(($# > 0 ? 1 : 0))
 done
 
-mkdir -p chromium-extensions
+mkdir -p ${__PROJECT__}/var/chromium-extensions
 cd ${__PROJECT__}/var/chromium-extensions
 
 # Clear Site Data


### PR DESCRIPTION
﻿## Summary
- create the Chromium extension download directory under var/chromium-extensions
- keep the subsequent cd target aligned with the directory that is created

## Verification
- mocked tools/download-chromium-extension.sh from a clean temp project with fake curl and unzip
- bash -n tools/download-chromium-extension.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
