### PR TITLE
Fix duplicate mirror rule id

### DIFF
--- a/extension/rules/mirrors/code.jquery.com-ui.json
+++ b/extension/rules/mirrors/code.jquery.com-ui.json
@@ -91,7 +91,7 @@
     }
   },
   {
-    "id": 5,
+    "id": 6,
     "priority": 100,
     "action": {
       "type": "redirect",

--- a/test/check-rules.js
+++ b/test/check-rules.js
@@ -50,10 +50,25 @@ function checkUrlFilters(filePath, rule) {
   }
 }
 
+function checkDuplicateRuleIds(filePath, rules) {
+  const seenIds = new Set();
+
+  for (const rule of rules) {
+    if (seenIds.has(rule.id)) {
+      errors.push(`${filePath}: contains duplicate rule id ${rule.id}`);
+      continue;
+    }
+
+    seenIds.add(rule.id);
+  }
+}
+
 for (const directory of ruleDirectories) {
   for (const filePath of walkJsonFiles(directory)) {
     const rules = JSON.parse(fs.readFileSync(filePath, "utf8"));
     const ruleList = Array.isArray(rules) ? rules : [rules];
+
+    checkDuplicateRuleIds(filePath, ruleList);
 
     for (const rule of ruleList) {
       checkDomainCondition(


### PR DESCRIPTION
﻿## Summary
- make the ByteDance jqueryui mirror candidate use a unique id
- add a rules check for duplicate rule ids within each JSON file

## Verification
- npm run rules:check
- node --check test/check-rules.js
- npm run manifest:check
- npm run icons:check
- git diff --check
