### PR TITLE
Ignore non-numeric Chromium mirror entries

### DIFF
--- a/tools/get-latest-chromium-version-main.py
+++ b/tools/get-latest-chromium-version-main.py
@@ -9,8 +9,9 @@ def get_latest_aliyun_mirror_chromium_version(os):
     # print(type(res))
     maxs = [];
     for i in res:
-        i["name"] = i['name'].rstrip("/")
-        maxs.append(int(i['name']))
+        name = i['name'].rstrip("/")
+        if name.isdigit():
+            maxs.append(int(name))
     maxs.sort(key=None, reverse=True)
     return maxs[0]
 


### PR DESCRIPTION
﻿## Summary
- ignore non-numeric entries in npmmirror Chromium snapshot directories
- restore Linux and macOS x86 mirror URL resolution when hash entries are present

## Verification
- python tools/get-latest-chromium-version-main.py linux
- python tools/get-latest-chromium-version-main.py darwin
- python tools/get-latest-chromium-version-main.py darwin-arm64
- python tools/get-latest-chromium-version-main.py win
- python -m py_compile tools/get-latest-chromium-version-main.py
- bash -n tools/download-chromium.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
