### PR TITLE
Fail Chromium download without URL

### DIFF
--- a/tools/download-chromium.sh
+++ b/tools/download-chromium.sh
@@ -122,9 +122,10 @@ if [ -n "$DOWNLOAD_CHROMIUM_URL" ]; then
     ;;
   *)
     echo 'no match OS'
-    exit 0
+    exit 1
     ;;
   esac
 else
   echo ' please check DOWNLOAD_CHROMIUM_URL !'
+  exit 1
 fi


### PR DESCRIPTION
﻿## Summary
- return a non-zero status when Chromium download cannot resolve a URL
- return a non-zero status for unsupported OS after a URL is selected

## Verification
- bash tools/download-chromium.sh --mirror invalid now reports EXIT=1
- bash -n tools/download-chromium.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
