### PR TITLE
Fail Node runtime setup on unsupported platform

### DIFF
--- a/tools/setup-nodejs-runtime.sh
+++ b/tools/setup-nodejs-runtime.sh
@@ -33,7 +33,7 @@ case $OS in
     ;;
   *)
     echo '暂未配置的 OS '
-    exit 0
+    exit 1
     ;;
   esac
   ;;
@@ -48,7 +48,7 @@ case $ARCH in
   ;;
 *)
   echo '暂未配置的 ARCH '
-  exit 0
+  exit 1
   ;;
 esac
 


### PR DESCRIPTION
﻿## Summary
- return a non-zero status when Node runtime setup sees an unsupported OS
- return a non-zero status when Node runtime setup sees an unsupported CPU architecture

## Verification
- mocked tools/setup-nodejs-runtime.sh with uname -s = FreeBSD and verified non-zero exit
- mocked tools/setup-nodejs-runtime.sh with uname -m = riscv64 and verified non-zero exit
- bash -n tools/setup-nodejs-runtime.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
