### PR TITLE
Fail browser launch on unsupported OS

### DIFF
--- a/tools/chromium.sh
+++ b/tools/chromium.sh
@@ -60,7 +60,7 @@ case $OS in
   ;;
 *)
   echo 'current script no support !'
-  exit 0
+  exit 1
   ;;
 esac
 

--- a/tools/firefox-web-ext.sh
+++ b/tools/firefox-web-ext.sh
@@ -34,11 +34,11 @@ case $OS in
   ;;
 'MINGW64_NT'* | 'MSYS_NT'*)
   # FIREFOX="C:\Program Files\Mozilla Firefox\firefox.exe"
-  exit 0
+  exit 1
   ;;
 *)
   echo 'current script no support !'
-  exit 0
+  exit 1
   ;;
 esac
 

--- a/tools/firefox.sh
+++ b/tools/firefox.sh
@@ -53,11 +53,11 @@ case $OS in
   ;;
 'MINGW64_NT'* | 'MSYS_NT'*)
   # FIREFOX="C:\Program Files\Mozilla Firefox\firefox.exe"
-  exit 0
+  exit 1
   ;;
 *)
   echo 'current script no support !'
-  exit 0
+  exit 1
   ;;
 esac
 


### PR DESCRIPTION
﻿## Summary
- return a non-zero status when chromium.sh sees an unsupported OS
- return a non-zero status when firefox.sh and firefox-web-ext.sh see unsupported OS paths
- keep successful launch paths unchanged

## Verification
- mocked chromium.sh, firefox.sh, and firefox-web-ext.sh with uname -s = FreeBSD and verified non-zero exits
- bash -n tools/chromium.sh tools/firefox.sh tools/firefox-web-ext.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
