### PR TITLE
Fail Firefox downloads on unsupported OS

### DIFF
--- a/tools/download-firefox-latest-stable.sh
+++ b/tools/download-firefox-latest-stable.sh
@@ -67,4 +67,8 @@ case $OS in
 'MINGW64_NT'* | 'MSYS_NT'*)
   curl -Lo firefox.exe "https://download.mozilla.org/?product=firefox-latest&os=win64&lang=en-US"
   ;;
+*)
+  echo 'no match OS'
+  exit 1
+  ;;
 esac

--- a/tools/download-firefox.sh
+++ b/tools/download-firefox.sh
@@ -99,4 +99,8 @@ case $OS in
   DOWNLOAD_FIREFOX_URL=${DOWNLOAD_FIREFOX_URL_PREFIX}/${FIREFOX_VERSION}/win64/en-US/Firefox%20Setup%20${FIREFOX_VERSION}.exe
   curl -Lo firefox.exe ${DOWNLOAD_FIREFOX_URL}
   ;;
+*)
+  echo 'no match OS'
+  exit 1
+  ;;
 esac


### PR DESCRIPTION
﻿## Summary
- return a non-zero status when download-firefox.sh sees an unsupported OS
- return a non-zero status when download-firefox-latest-stable.sh sees an unsupported OS

## Verification
- mocked both Firefox download scripts with uname -s = FreeBSD and verified non-zero exits
- bash -n tools/download-firefox.sh tools/download-firefox-latest-stable.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
