### PR TITLE
Use Firefox-safe static redirect rules

### DIFF
--- a/extension/rules/rules_redirect_main_firefox.json
+++ b/extension/rules/rules_redirect_main_firefox.json
@@ -1,0 +1,199 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "scheme": "https",
+          "host": "ajax.loli.net"
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "|http*://ajax.googleapis.com",
+      "requestDomains": ["ajax.googleapis.com"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "other"
+      ]
+    }
+  },
+  {
+    "id": 2,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "scheme": "https",
+          "host": "fonts.googleapis.cn"
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "|http*://fonts.googleapis.com",
+      "requestDomains": ["fonts.googleapis.com"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "other"
+      ]
+    }
+  },
+  {
+    "id": 3,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "scheme": "https",
+          "host": "themes.loli.net"
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "|http*://themes.googleusercontent.com",
+      "requestDomains": ["themes.googleusercontent.com"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "other"
+      ]
+    }
+  },
+  {
+    "id": 4,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "scheme": "https",
+          "host": "fonts.gstatic.cn"
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "|http*://fonts.gstatic.com",
+      "requestDomains": ["fonts.gstatic.com"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "other"
+      ]
+    }
+  },
+  {
+    "id": 5,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "scheme": "https",
+          "host": "gravatar.loli.net"
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "|http*://*.gravatar.com",
+      "requestDomains": [
+        "secure.gravatar.com",
+        "www.gravatar.com",
+        "cn.gravatar.com",
+        "en.gravatar.com"
+      ],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "other"
+      ]
+    }
+  },
+  {
+    "id": 10,
+    "priority": 1,
+    "action": {
+      "type": "redirect",
+      "redirect": {
+        "transform": {
+          "scheme": "https",
+          "host": "fastly.jsdelivr.net"
+        }
+      }
+    },
+    "condition": {
+      "urlFilter": "|http*://cdn.jsdelivr.net",
+      "requestDomains": ["cdn.jsdelivr.net"],
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame",
+        "stylesheet",
+        "script",
+        "image",
+        "font",
+        "object",
+        "xmlhttprequest",
+        "ping",
+        "csp_report",
+        "media",
+        "websocket",
+        "other"
+      ]
+    }
+  }
+]

--- a/test/check-v3-manifest.py
+++ b/test/check-v3-manifest.py
@@ -23,6 +23,14 @@ def require(condition, message):
         raise AssertionError(message)
 
 
+def load_rule_resource(rule_path):
+    return json.loads((project_dir / "extension" / rule_path).read_text(encoding="utf-8"))
+
+
+def rule_list(rules):
+    return rules if isinstance(rules, list) else [rules]
+
+
 chromium_manifest = generate_manifest("chromium")
 require(
     chromium_manifest.get("background", {}).get("service_worker")
@@ -35,6 +43,14 @@ require(
 )
 require("options_ui" in chromium_manifest, "chromium manifest must keep options_ui")
 require("sandbox" in chromium_manifest, "chromium manifest must keep sandbox")
+chromium_rule_paths = {
+    rule["path"]
+    for rule in chromium_manifest["declarative_net_request"]["rule_resources"]
+}
+require(
+    "rules/rules_redirect_main.json" in chromium_rule_paths,
+    "chromium manifest must use the full redirect ruleset",
+)
 
 firefox_manifest = generate_manifest("firefox")
 firefox_rule_paths = {
@@ -55,5 +71,19 @@ require(
     "rules/rules-default-domains-helper.json" not in firefox_rule_paths,
     "firefox manifest must not reference rules-default-domains-helper.json",
 )
+require(
+    "rules/rules_redirect_main.json" not in firefox_rule_paths,
+    "firefox manifest must not reference the chromium regex redirect ruleset",
+)
+require(
+    "rules/rules_redirect_main_firefox.json" in firefox_rule_paths,
+    "firefox manifest must use the Firefox-compatible redirect ruleset",
+)
+for rule_path in firefox_rule_paths:
+    for rule in rule_list(load_rule_resource(rule_path)):
+        require(
+            "regexFilter" not in rule.get("condition", {}),
+            f"firefox static rule {rule_path}#{rule.get('id')} must not use regexFilter",
+        )
 
 print("Manifest checks passed.")

--- a/tools/update-v3-manifest.py
+++ b/tools/update-v3-manifest.py
@@ -43,6 +43,14 @@ def remove_rule_resources(manifest, paths):
     return manifest
 
 
+def replace_rule_resource_path(manifest, old_path, new_path):
+    rule_resources = manifest.get('declarative_net_request', {}).get('rule_resources', [])
+    for rule_resource in rule_resources:
+        if rule_resource.get('path') == old_path:
+            rule_resource['path'] = new_path
+    return manifest
+
+
 if __name__ == '__main__':
     comment = '''
       用法：python3 tools/update-v3-manifest.py [ chromium | firefox ]
@@ -131,6 +139,11 @@ if __name__ == '__main__':
     manifest_data = set_manifest_data(manifest_data, 'browser_specific_settings', browser_specific_settings)
     if browser == 'firefox':
         manifest_data = set_manifest_data(manifest_data, 'options_ui', '')
+        manifest_data = replace_rule_resource_path(
+            manifest_data,
+            'rules/rules_redirect_main.json',
+            'rules/rules_redirect_main_firefox.json',
+        )
         manifest_data = remove_rule_resources(
             manifest_data,
             {


### PR DESCRIPTION
﻿## Summary
- add a Firefox-compatible static redirect ruleset without regexFilter rules
- point generated Firefox manifests at that ruleset instead of the Chromium regex ruleset
- extend manifest checks to prevent Firefox static rule resources from using regexFilter

Fixes part of #179.

## Verification
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- python -m py_compile tools/update-v3-manifest.py test/check-v3-manifest.py
- node test/check-rules.js
- git diff --check

Note: bash release-archive-v3.sh could not complete in this Windows bash environment because zip is not installed; failure occurred before Firefox packaging.
