### PR TITLE
Sync single remote static ruleset

### DIFF
--- a/extension/options_ui/js/AdvanceBundle/Components/globalDynamicRuleMain.js
+++ b/extension/options_ui/js/AdvanceBundle/Components/globalDynamicRuleMain.js
@@ -44,12 +44,12 @@ let bindSyncRemoteStaticRuleEventListener = () => {
         }
       });
 
-      if (!new_rules_urls) {
+      if (new_rules_urls.length === 0) {
         return;
       }
       let result = await utils.fetchAll(new_rules_urls, utils.getContent);
 
-      if (result.length > 1) {
+      if (result.length > 0) {
         //let dynamic_id_index = parseInt(new Date().getTime() / 1000);
         let dynamic_id_index = id_ranges["sync_remote_static_rule"][0];
         let need_rules = [];


### PR DESCRIPTION
﻿## Summary
- return early only when the remote static ruleset URL list is empty
- allow syncing a remote manifest that has exactly one enabled static ruleset

## Verification
- node --check extension/options_ui/js/AdvanceBundle/Components/globalDynamicRuleMain.js
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
