### PR TITLE
Fix sandbox postMessage target origin

### DIFF
--- a/extension/sandbox/js/app.js
+++ b/extension/sandbox/js/app.js
@@ -57,11 +57,17 @@ list_box.addEventListener("click", (event) => {
   //console.log(event.target.nodeName);
   if (event.target.nodeName === "PRE") {
     let url = event.target.innerText;
+    let parentOrigin = document.referrer
+      ? new URL(document.referrer).origin
+      : "*";
+    if (parentOrigin === "null") {
+      parentOrigin = "*";
+    }
     window.parent.postMessage(
       JSON.stringify({
         url: url
       }),
-      location.origin + "/options_ui/index.html"
+      parentOrigin
     );
     return;
 


### PR DESCRIPTION
﻿## Summary
- derive the parent page origin from document.referrer for sandbox demo messages
- stop passing a path-containing string as postMessage targetOrigin
- fall back to * only when the computed origin is opaque or unavailable

## Verification
- node --check extension/sandbox/js/app.js
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check

Browser interaction was not run in this environment.
