### PR TITLE
Clean macOS Firefox app before copy

### DIFF
--- a/tools/download-firefox-latest-stable.sh
+++ b/tools/download-firefox-latest-stable.sh
@@ -66,6 +66,7 @@ case $OS in
 
   # 将应用程序拷贝到指定目录
   mkdir -p ${__PROJECT__}/var/firefox
+  test -d "${__PROJECT__}/var/firefox/Firefox.app" && rm -rf "${__PROJECT__}/var/firefox/Firefox.app"
   cp -rf "${TMP_MOUNT_POINT}/Firefox.app" "${__PROJECT__}/var/firefox"
   ls -lh ${__PROJECT__}/var/firefox/
   cleanup_firefox_dmg_mount

--- a/tools/download-firefox.sh
+++ b/tools/download-firefox.sh
@@ -96,6 +96,7 @@ case $OS in
 
   # 将应用程序拷贝到指定目录
   mkdir -p ${__PROJECT__}/var/firefox
+  test -d "${__PROJECT__}/var/firefox/Firefox.app" && rm -rf "${__PROJECT__}/var/firefox/Firefox.app"
   cp -rf "${TMP_MOUNT_POINT}/Firefox.app" "${__PROJECT__}/var/firefox"
   ls -lh ${__PROJECT__}/var/firefox/
   cleanup_firefox_dmg_mount


### PR DESCRIPTION
﻿## Summary
- remove an existing macOS Firefox.app before copying a freshly mounted DMG app
- keep versioned and latest-stable Firefox download scripts consistent with the Linux branch cleanup behavior

## Verification
- bash -n tools/download-firefox.sh tools/download-firefox-latest-stable.sh
- git diff --check
- npm run manifest:check
- npm run rules:check
- npm run icons:check

macOS hdiutil flow was not run in this Windows environment.
