### PR TITLE
Guard options page opening

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -6,7 +6,15 @@ chrome.action.onClicked.addListener((tab) => {
 
   // 注释的原因：减少误打开选项页
   // 默认候选项切换已完成，现在可以打开了
+  if (!chrome.runtime.getManifest().options_ui) {
+    return;
+  }
   chrome.runtime.openOptionsPage((w) => {
+    if (chrome.runtime.lastError) {
+      console.error(chrome.runtime.lastError.message);
+      return;
+    }
+
     console.log(w);
   });
 });


### PR DESCRIPTION
﻿## Summary
- skip opening the options page when the active manifest does not declare options_ui
- log chrome.runtime.lastError from openOptionsPage instead of silently continuing

This prevents the Firefox package, which intentionally removes options_ui, from trying to open a missing options page when the extension action is clicked.

## Verification
- node --check extension/js/background.js
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
