### PR TITLE
Fix Windows workflow prepare step

### DIFF
--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -14,10 +14,11 @@ jobs:
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
-          env
+          Get-ChildItem Env:
           ipconfig
-          uname -a
-          pwd
+          $PSVersionTable
+          [System.Environment]::OSVersion.VersionString
+          Get-Location
           ipconfig /all
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
﻿## Summary
- replace Unix-only diagnostics in the Windows prepare step with PowerShell-native commands
- keep the existing git and network diagnostics without failing before checkout

## Verification
- reproduced that `env` and `uname -a` fail in PowerShell
- ran the replacement PowerShell commands successfully
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
