### PR TITLE
Fix latest Firefox download on Linux arm64

### DIFF
--- a/tools/download-firefox-latest-stable.sh
+++ b/tools/download-firefox-latest-stable.sh
@@ -43,10 +43,23 @@ echo "${OS}-${ARCH}"
 
 case $OS in
 "Linux")
+  FIREFOX_OS="linux64"
+  case $ARCH in
+  "x86_64" | "amd64")
+    FIREFOX_OS="linux64"
+    ;;
+  "aarch64" | "arm64")
+    FIREFOX_OS="linux64-aarch64"
+    ;;
+  *)
+    echo "unsupported Linux ARCH: ${ARCH}"
+    exit 1
+    ;;
+  esac
   test -f firefox.tar.bz2 && rm -rf firefox.tar.bz2
   test -f firefox.tar.xz && rm -rf firefox.tar.xz
   test -d firefox && rm -rf firefox
-  curl -Lo firefox.tar.xz "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US"
+  curl -fSLo firefox.tar.xz "https://download.mozilla.org/?product=firefox-latest&os=${FIREFOX_OS}&lang=en-US"
   tar -xJvf firefox.tar.xz
   ;;
 "Darwin")


### PR DESCRIPTION
﻿## Summary
- choose the Mozilla `linux64-aarch64` download target for latest Firefox on Linux arm64/aarch64
- fail on unsupported Linux architectures instead of downloading the x86_64 package
- make the Linux latest Firefox download fail on HTTP errors

## Verification
- bash -n tools/download-firefox-latest-stable.sh
- curl -I https://download.mozilla.org/?product=firefox-latest&os=linux64-aarch64&lang=en-US
- curl -I https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- bash -n release-archive.sh release-archive-v3.sh tools/*.sh
- git diff --check
