### PR TITLE
Fail Chromium extension download on unzip errors

### DIFF
--- a/tools/download-chromium-extension.sh
+++ b/tools/download-chromium-extension.sh
@@ -60,7 +60,7 @@ file_name='replace-google-cdn'
 
 download_url="https://clients2.google.com/service/update2/crx?response=redirect&prodversion=114.0.5726.0&acceptformat=crx2,crx3&x=id%3D${extension_id}%26uc&nacl_arch=x86-64"
 
-curl -Lo "${file_name}.crx" $download_url
+curl -fSLo "${file_name}.crx" "$download_url"
 
 # 使用不同的代理方式
 # proxychains curl -Lo google-translate.crx $download_url
@@ -68,8 +68,6 @@ curl -Lo "${file_name}.crx" $download_url
 # curl --proxy "socks5h://127.0.0.1:2000" -Lo google-translate.crx $download_url
 
 # crx 是经过定制的 zip 压缩格式文件
-set +e
 unzip -d ${file_name} "${file_name}.crx"
-set -e
 
 cd ${__PROJECT__}/var/chromium-extensions


### PR DESCRIPTION
﻿## Summary
- make Chromium extension CRX downloads fail on HTTP errors
- propagate `unzip` failures instead of returning success after a failed extraction

## Verification
- mocked `unzip` failure now reports `EXIT:9` instead of `EXIT:0`
- bash -n tools/download-chromium-extension.sh
- bash -n release-archive.sh release-archive-v3.sh tools/*.sh
- npm run manifest:check
- npm run rules:check
- npm run icons:check
- git diff --check
