### PR TITLE
Harden sandbox message handling

### DIFF
--- a/extension/options_ui/js/AdvanceBundle/Controller/advanceController.js
+++ b/extension/options_ui/js/AdvanceBundle/Controller/advanceController.js
@@ -6,26 +6,55 @@ import SelfDefineRule from "../Components/selfDefineRule.js";
 
 import showRuleList from "../../CommonBundle/Components/showRuleList.js";
 
+let getSandboxWindow = () => {
+  let iframe = document.querySelector("#external_page");
+  return iframe ? iframe.contentWindow : null;
+};
+
+let parseSandboxMessage = (message) => {
+  if (typeof message !== "string") {
+    return null;
+  }
+
+  try {
+    return JSON.parse(message);
+  } catch (error) {
+    console.error("Invalid sandbox message", error);
+    return null;
+  }
+};
+
+let isOpenableSandboxUrl = (url) => {
+  try {
+    let parsedUrl = new URL(url);
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  } catch (error) {
+    console.error("Invalid sandbox url", error);
+    return false;
+  }
+};
+
 let messageReciver = () => {
   window.addEventListener(
     "message",
     (event) => {
-      console.log(event, event.source);
-      event.source.postMessage("hi there yourself!  the secret response ", "*");
-      //event.source.postMessage("hi there yourself!  the secret response ",event.origin);
-      //event.source.postMessage("hi there yourself!  the secret response ",location.origin+iframe_src);
-      console.log(event.data);
-      if (event.origin === "null") {
-        let data = JSON.parse(event.data);
-        console.log(data);
-
-        if (data.url) {
-          let url = data.url;
-          chrome.tabs.create({ url }, (callback) => {
-            console.log(callback);
-          });
-        }
+      if (event.origin !== "null" || event.source !== getSandboxWindow()) {
+        return;
       }
+
+      let data = parseSandboxMessage(event.data);
+      if (!data || !data.url || !isOpenableSandboxUrl(data.url)) {
+        return;
+      }
+
+      chrome.tabs.create({ url: data.url }, (callback) => {
+        if (chrome.runtime.lastError) {
+          console.error(chrome.runtime.lastError.message);
+          return;
+        }
+
+        console.log(callback);
+      });
     },
     false
   );

--- a/extension/options_ui/js/AdvanceBundle/Controller/advanceController.js
+++ b/extension/options_ui/js/AdvanceBundle/Controller/advanceController.js
@@ -6,6 +6,8 @@ import SelfDefineRule from "../Components/selfDefineRule.js";
 
 import showRuleList from "../../CommonBundle/Components/showRuleList.js";
 
+let sandboxOpenUrlMessageType = "replace-google-cdn:open-preview-url";
+
 let getSandboxWindow = () => {
   let iframe = document.querySelector("#external_page");
   return iframe ? iframe.contentWindow : null;
@@ -43,7 +45,12 @@ let messageReciver = () => {
       }
 
       let data = parseSandboxMessage(event.data);
-      if (!data || !data.url || !isOpenableSandboxUrl(data.url)) {
+      if (
+        !data ||
+        data.type !== sandboxOpenUrlMessageType ||
+        !data.url ||
+        !isOpenableSandboxUrl(data.url)
+      ) {
         return;
       }
 

--- a/extension/sandbox/js/app.js
+++ b/extension/sandbox/js/app.js
@@ -36,6 +36,7 @@ let preview_url = [
 ];
 
 let is_iframe = self !== top;
+let openUrlMessageType = "replace-google-cdn:open-preview-url";
 let list_box = document.querySelector(".box");
 let list = "";
 preview_url.map((value, index) => {
@@ -65,6 +66,7 @@ list_box.addEventListener("click", (event) => {
     }
     window.parent.postMessage(
       JSON.stringify({
+        type: openUrlMessageType,
         url: url
       }),
       parentOrigin


### PR DESCRIPTION
## Summary
- only accept sandbox messages from the expected iframe window
- ignore malformed sandbox messages and non-http(s) URLs before opening tabs
- report chrome.tabs.create runtime errors

## Validation
- node --check extension/options_ui/js/AdvanceBundle/Controller/advanceController.js