### PR TITLE
Validate Firefox extension downloads

### DIFF
--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -68,29 +68,19 @@ jobs:
           Start-Process -FilePath $installer -ArgumentList "/A /S"
 
           $deadline = (Get-Date).AddMinutes(3)
-          $firefoxReady = $false
           do {
             Start-Sleep -Seconds 5
-            if (Test-Path $firefox) {
-              $version = & $firefox --version 2>&1
-              Write-Host $version
-              if ("$version" -match "Mozilla Firefox") {
-                $firefoxReady = $true
-                break
-              }
+            $firefoxReady = Test-Path $firefox
+            if ($firefoxReady) {
+              break
             }
           } while ((Get-Date) -lt $deadline)
 
           if (-not $firefoxReady) {
-            throw "Firefox was not ready before timeout"
+            throw "Firefox was not installed before timeout"
           }
 
           Get-ChildItem "C:\Program Files\Mozilla Firefox"
-          $version = & $firefox --version 2>&1
-          Write-Host $version
-          if ("$version" -notmatch "Mozilla Firefox") {
-            throw "Firefox version check failed: $version"
-          }
 
       - name: show browser version
         shell: cmd

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -72,8 +72,9 @@ jobs:
           do {
             Start-Sleep -Seconds 5
             if (Test-Path $firefox) {
-              & $firefox --version
-              if ($LASTEXITCODE -eq 0) {
+              $version = & $firefox --version 2>&1
+              Write-Host $version
+              if ("$version" -match "Mozilla Firefox") {
                 $firefoxReady = $true
                 break
               }
@@ -85,9 +86,10 @@ jobs:
           }
 
           Get-ChildItem "C:\Program Files\Mozilla Firefox"
-          & $firefox --version
-          if ($LASTEXITCODE -ne 0) {
-            throw "Firefox version check failed with exit code $LASTEXITCODE"
+          $version = & $firefox --version 2>&1
+          Write-Host $version
+          if ("$version" -notmatch "Mozilla Firefox") {
+            throw "Firefox version check failed: $version"
           }
 
       - name: show browser version

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -64,19 +64,31 @@ jobs:
           Get-Location
 
           $installer = Join-Path (Get-Location) "var\firefox.exe"
-          $process = Start-Process -FilePath $installer -ArgumentList "/S" -PassThru
-          if (-not $process.WaitForExit(120000)) {
-            Stop-Process -Id $process.Id -Force
-            throw "Firefox installer timed out"
-          }
-          if ($process.ExitCode -ne 0) {
-            throw "Firefox installer failed with exit code $($process.ExitCode)"
-          }
+          $firefox = "C:\Program Files\Mozilla Firefox\firefox.exe"
+          Start-Process -FilePath $installer -ArgumentList "/S"
 
-          Start-Sleep -Seconds 30
+          $deadline = (Get-Date).AddMinutes(3)
+          $firefoxReady = $false
+          do {
+            Start-Sleep -Seconds 5
+            if (Test-Path $firefox) {
+              & $firefox --version
+              if ($LASTEXITCODE -eq 0) {
+                $firefoxReady = $true
+                break
+              }
+            }
+          } while ((Get-Date) -lt $deadline)
+
+          if (-not $firefoxReady) {
+            throw "Firefox was not ready before timeout"
+          }
 
           Get-ChildItem "C:\Program Files\Mozilla Firefox"
-          & "C:\Program Files\Mozilla Firefox\firefox.exe" --version
+          & $firefox --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "Firefox version check failed with exit code $LASTEXITCODE"
+          }
 
       - name: show browser version
         shell: cmd

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -58,24 +58,25 @@ jobs:
           fi
 
       - name: install firefox
-        shell: cmd
+        shell: powershell
         run: |
-          DIR
-          ECHO %CD%
+          Get-ChildItem
+          Get-Location
 
-          :: msiexec /package /qn  "%CD%\var\firefox.msi"
-          :: var\firefox.exe /?
-          :: start var\firefox.exe /S
+          $installer = Join-Path (Get-Location) "var\firefox.exe"
+          $process = Start-Process -FilePath $installer -ArgumentList "/S" -PassThru
+          if (-not $process.WaitForExit(120000)) {
+            Stop-Process -Id $process.Id -Force
+            throw "Firefox installer timed out"
+          }
+          if ($process.ExitCode -ne 0) {
+            throw "Firefox installer failed with exit code $($process.ExitCode)"
+          }
 
-          ::  静默安装 firefox
-          var\firefox.exe /A /S
-          timeout /T 30 /NOBREAK
+          Start-Sleep -Seconds 30
 
-          :: show firefox install directory
-          DIR "C:\Program Files\Mozilla Firefox"
-
-          :: show firefox version
-          "C:\Program Files\Mozilla Firefox\firefox.exe" --version
+          Get-ChildItem "C:\Program Files\Mozilla Firefox"
+          & "C:\Program Files\Mozilla Firefox\firefox.exe" --version
 
       - name: show browser version
         shell: cmd

--- a/.github/workflows/windows-x86_64.yml
+++ b/.github/workflows/windows-x86_64.yml
@@ -65,7 +65,7 @@ jobs:
 
           $installer = Join-Path (Get-Location) "var\firefox.exe"
           $firefox = "C:\Program Files\Mozilla Firefox\firefox.exe"
-          Start-Process -FilePath $installer -ArgumentList "/S"
+          Start-Process -FilePath $installer -ArgumentList "/A /S"
 
           $deadline = (Get-Date).AddMinutes(3)
           $firefoxReady = $false

--- a/tools/download-firefox-extension.sh
+++ b/tools/download-firefox-extension.sh
@@ -24,6 +24,7 @@ cd ${__PROJECT__}/var/firefox-extensions
 
 extension_file=traduzir_paginas_web-9.8.1.0.xpi
 
+rm -f "${extension_file}"
 curl -fSLo "${extension_file}" https://addons.mozilla.org/firefox/downloads/file/4126844/traduzir_paginas_web-9.8.1.0.xpi
 test -s "${extension_file}"
 unzip -t "${extension_file}" >/dev/null

--- a/tools/download-firefox-extension.sh
+++ b/tools/download-firefox-extension.sh
@@ -22,7 +22,11 @@ cd ${__PROJECT__}/var/firefox-extensions
 
 # download firefox extension
 
-curl -Lo traduzir_paginas_web-9.8.1.0.xpi https://addons.mozilla.org/firefox/downloads/file/4126844/traduzir_paginas_web-9.8.1.0.xpi
+extension_file=traduzir_paginas_web-9.8.1.0.xpi
+
+curl -fSLo "${extension_file}" https://addons.mozilla.org/firefox/downloads/file/4126844/traduzir_paginas_web-9.8.1.0.xpi
+test -s "${extension_file}"
+unzip -t "${extension_file}" >/dev/null
 
 # 解压扩展到  profile 目录
 # mkdir -p "$profile_folder/extensions/{036a55b4-5e72-4d05-a06c-cba2dfcc134a}.xpi"


### PR DESCRIPTION
## Summary
- make Firefox extension downloads fail on HTTP errors
- reject empty XPI files
- verify the downloaded XPI is a readable zip archive

## Validation
- bash -n tools/download-firefox-extension.sh