### PR TITLE
Fail Firefox downloads on HTTP errors

### DIFF
--- a/tools/download-firefox-latest-stable.sh
+++ b/tools/download-firefox-latest-stable.sh
@@ -60,10 +60,13 @@ case $OS in
   test -f firefox.tar.xz && rm -rf firefox.tar.xz
   test -d firefox && rm -rf firefox
   curl -fSLo firefox.tar.xz "https://download.mozilla.org/?product=firefox-latest&os=${FIREFOX_OS}&lang=en-US"
+  test -s firefox.tar.xz
   tar -xJvf firefox.tar.xz
   ;;
 "Darwin")
-  curl -Lo firefox.dmg "https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US"
+  test -f firefox.dmg && rm -rf firefox.dmg
+  curl -fSLo firefox.dmg "https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US"
+  test -s firefox.dmg
   # 使用 hdiutil 挂载 DMG格式 文件
   UUID=$(uuidgen)
   TMP_MOUNT_POINT=/tmp/${UUID}
@@ -88,7 +91,9 @@ case $OS in
   ;;
 
 'MINGW64_NT'* | 'MSYS_NT'*)
-  curl -Lo firefox.exe "https://download.mozilla.org/?product=firefox-latest&os=win64&lang=en-US"
+  test -f firefox.exe && rm -rf firefox.exe
+  curl -fSLo firefox.exe "https://download.mozilla.org/?product=firefox-latest&os=win64&lang=en-US"
+  test -s firefox.exe
   ;;
 *)
   echo 'no match OS'

--- a/tools/download-firefox-latest-stable.sh
+++ b/tools/download-firefox-latest-stable.sh
@@ -64,7 +64,7 @@ case $OS in
   tar -xJvf firefox.tar.xz
   ;;
 "Darwin")
-  test -f firefox.dmg && rm -rf firefox.dmg
+  rm -f firefox.dmg
   curl -fSLo firefox.dmg "https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US"
   test -s firefox.dmg
   # 使用 hdiutil 挂载 DMG格式 文件
@@ -91,7 +91,7 @@ case $OS in
   ;;
 
 'MINGW64_NT'* | 'MSYS_NT'*)
-  test -f firefox.exe && rm -rf firefox.exe
+  rm -f firefox.exe
   curl -fSLo firefox.exe "https://download.mozilla.org/?product=firefox-latest&os=win64&lang=en-US"
   test -s firefox.exe
   ;;

--- a/tools/download-firefox.sh
+++ b/tools/download-firefox.sh
@@ -65,7 +65,8 @@ case $OS in
   test -f firefox.tar && rm -rf firefox.tar
   test -d firefox && rm -rf firefox
   DOWNLOAD_FIREFOX_URL=${DOWNLOAD_FIREFOX_URL_PREFIX}/${FIREFOX_VERSION}/linux-${ARCH}/en-US/firefox-${FIREFOX_VERSION}.tar.xz
-  curl -Lo firefox.tar.xz ${DOWNLOAD_FIREFOX_URL}
+  curl -fSLo firefox.tar.xz "${DOWNLOAD_FIREFOX_URL}"
+  test -s firefox.tar.xz
   xz -d firefox.tar.xz
   tar -xvf firefox.tar
   ;;
@@ -73,7 +74,8 @@ case $OS in
   FIREFOX_DMG_FILE=firefox.dmg
   test -f ${FIREFOX_DMG_FILE} && rm -rf ${FIREFOX_DMG_FILE}
   DOWNLOAD_FIREFOX_URL=${DOWNLOAD_FIREFOX_URL_PREFIX}/${FIREFOX_VERSION}/mac/en-US/Firefox%20${FIREFOX_VERSION}.dmg
-  curl -Lo ${FIREFOX_DMG_FILE} ${DOWNLOAD_FIREFOX_URL}
+  curl -fSLo "${FIREFOX_DMG_FILE}" "${DOWNLOAD_FIREFOX_URL}"
+  test -s "${FIREFOX_DMG_FILE}"
 
   # brew install p7zip
   # 使用 7-zip 解压
@@ -107,7 +109,8 @@ case $OS in
 'MINGW64_NT'* | 'MSYS_NT'*)
   test -f firefox.exe && rm -rf firefox.exe
   DOWNLOAD_FIREFOX_URL=${DOWNLOAD_FIREFOX_URL_PREFIX}/${FIREFOX_VERSION}/win64/en-US/Firefox%20Setup%20${FIREFOX_VERSION}.exe
-  curl -Lo firefox.exe ${DOWNLOAD_FIREFOX_URL}
+  curl -fSLo firefox.exe "${DOWNLOAD_FIREFOX_URL}"
+  test -s firefox.exe
   ;;
 *)
   echo 'no match OS'


### PR DESCRIPTION
## Summary
- use curl -fSLo for Firefox runtime downloads
- check downloaded artifacts are non-empty before extraction/use
- remove stale latest-stable macOS and Windows artifacts before redownloading

## Validation
- bash -n tools/download-firefox.sh tools/download-firefox-latest-stable.sh