### PR TITLE
Handle invalid rule JSON input

### DIFF
--- a/extension/options_ui/js/AdvanceBundle/Components/selfDefineRule.js
+++ b/extension/options_ui/js/AdvanceBundle/Components/selfDefineRule.js
@@ -9,11 +9,23 @@ import showRuleList from "../../CommonBundle/Components/showRuleList.js";
 import { rule_example } from "../Config/rule_example_conf.js";
 import { showDynamicRules } from "../../CommonBundle/Components/showDynamicRules.js";
 
+let noticeTimeoutHandler = null;
+
 let showNotice = (message) => {
   let notice = document.querySelector(".notice");
   if (notice) {
     notice.innerText = message;
   }
+};
+
+let clearNoticeLater = () => {
+  if (noticeTimeoutHandler) {
+    clearTimeout(noticeTimeoutHandler);
+  }
+
+  noticeTimeoutHandler = setTimeout(() => {
+    showNotice("");
+  }, 6000);
 };
 
 let parseSelfDefineRuleJSON = (rule_str) => {
@@ -22,6 +34,7 @@ let parseSelfDefineRuleJSON = (rule_str) => {
   } catch (error) {
     console.error("Invalid self-defined rule JSON", error);
     showNotice("规则 JSON 格式错误：" + error.message);
+    clearNoticeLater();
     return undefined;
   }
 };

--- a/extension/options_ui/js/AdvanceBundle/Components/selfDefineRule.js
+++ b/extension/options_ui/js/AdvanceBundle/Components/selfDefineRule.js
@@ -9,11 +9,34 @@ import showRuleList from "../../CommonBundle/Components/showRuleList.js";
 import { rule_example } from "../Config/rule_example_conf.js";
 import { showDynamicRules } from "../../CommonBundle/Components/showDynamicRules.js";
 
+let showNotice = (message) => {
+  let notice = document.querySelector(".notice");
+  if (notice) {
+    notice.innerText = message;
+  }
+};
+
+let parseSelfDefineRuleJSON = (rule_str) => {
+  try {
+    return JSON.parse(rule_str);
+  } catch (error) {
+    console.error("Invalid self-defined rule JSON", error);
+    showNotice("规则 JSON 格式错误：" + error.message);
+    return undefined;
+  }
+};
+
 let addSelfDefineRule = (type = "self_define_rule") => {
   let rule_str = document.querySelector(".new-add-rule-pannel").value;
   rule_str = rule_str.trim();
   if (rule_str.length > 2) {
-    let rules_arr = JSON.parse(rule_str);
+    showNotice("");
+
+    let rules_arr = parseSelfDefineRuleJSON(rule_str);
+    if (rules_arr === undefined) {
+      return;
+    }
+
     console.log("add rule origin content", rules_arr);
 
     let need_rules = [];

--- a/extension/options_ui/js/CommonBundle/Components/showRuleList.js
+++ b/extension/options_ui/js/CommonBundle/Components/showRuleList.js
@@ -13,6 +13,31 @@ import {
 let timeoutHandler = null;
 let isRuleListEventBound = false;
 
+let showNotice = (message) => {
+  document.querySelector(".notice").innerText = message;
+};
+
+let clearNoticeLater = () => {
+  if (timeoutHandler) {
+    clearTimeout(timeoutHandler);
+  }
+
+  timeoutHandler = setTimeout(() => {
+    showNotice("");
+  }, 6000);
+};
+
+let parseRuleJSON = (rule_str) => {
+  try {
+    return JSON.parse(rule_str);
+  } catch (error) {
+    console.error("Invalid rule JSON", error);
+    showNotice("规则 JSON 格式错误：" + error.message);
+    clearNoticeLater();
+    return undefined;
+  }
+};
+
 let bindButtonEventListener = () => {
   //备份单条规则
   document
@@ -23,7 +48,11 @@ let bindButtonEventListener = () => {
       let rule_str = document.querySelector("#rule-content-container").value;
       rule_str = rule_str.trim();
       if (rule_str.length) {
-        rule_str = JSON.parse(rule_str);
+        rule_str = parseRuleJSON(rule_str);
+        if (rule_str === undefined) {
+          return;
+        }
+
         let time = new Date().toISOString();
         console.log(time);
         //time=parseInt(new Date().getTime() / 1000).toString()
@@ -44,12 +73,16 @@ let bindButtonEventListener = () => {
     let rule_str = content_box.value;
     let rule_type = content_box.getAttribute("rule-type");
 
-    document.querySelector(".notice").innerText = "";
+    showNotice("");
     if (rule_type === "dynamic") {
       let rule_id = content_box.getAttribute("rule-id");
       rule_str = rule_str.trim();
       if (rule_str.length) {
-        let rule = JSON.parse(rule_str);
+        let rule = parseRuleJSON(rule_str);
+        if (rule === undefined) {
+          return;
+        }
+
         /*
         let time = new Date().toISOString();
         console.log(time);
@@ -62,20 +95,15 @@ let bindButtonEventListener = () => {
           let addRules = [rule],
             removeRuleIds = [rule_id];
           updateDynamicRules(addRules, removeRuleIds, () => {
-            document.querySelector(".notice").innerText = "规则修改成功";
+            showNotice("规则修改成功");
           });
         }
       }
     } else {
-      document.querySelector(".notice").innerText = "静态规则不允许修改";
+      showNotice("静态规则不允许修改");
     }
 
-    if (timeoutHandler) {
-      clearTimeout(timeoutHandler);
-    }
-    timeoutHandler = setTimeout(() => {
-      document.querySelector(".notice").innerText = "";
-    }, 6000);
+    clearNoticeLater();
   });
 
   /*


### PR DESCRIPTION
## Summary
- catch invalid JSON while backing up or updating editable rules
- catch invalid JSON while adding self-defined rules
- show the parse error in the existing options notice instead of throwing out of the click handler

## Validation
- node --check extension/options_ui/js/CommonBundle/Components/showRuleList.js
- node --check extension/options_ui/js/AdvanceBundle/Components/selfDefineRule.js