### PR TITLE
Remove unreachable deploy upload block

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -22,23 +22,3 @@ cd ${__PROJECT__}
 test -d ${__PROJECT__}/../ReplaceGoogleCDN-v3 && rm -rf ${__PROJECT__}/../ReplaceGoogleCDN-v3
 
 mv ${__PROJECT__}/dist/ReplaceGoogleCDN-v3 ${__PROJECT__}/../
-
-exit 0
-
-cd ${__PROJECT__}
-
-# 上传到指定服务器 例子
-
-key=/home/username/key.pem
-domain=chromium-extensions.jingjingxyk.com
-
-rsync -az -r -z -v -e "ssh -p 22 -i $key" --delete ${__ROOT__}/dist/ReplaceGoogleCDN-v2.zip root@${domain}:/data/webspace/chromium-extensions/ReplaceGoogleCDN-v2.zip
-rsync -az -r -z -v -e "ssh -p 22 -i $key" --delete ${__ROOT__}/dist/ReplaceGoogleCDN-v3.zip root@${domain}:/data/webspace/chromium-extensions/ReplaceGoogleCDN-v3.zip
-
-: <<'EOF'
-
-scp  -P 22 -i $key -v -C  \
--o StrictHostKeyChecking=no  \
-${__PROJECT__}/dist/*.zip root@${domain}:/data/webspace/chromium-extensions/
-
-EOF


### PR DESCRIPTION
## Summary
- remove the dead upload example after the deploy script's early exit
- eliminate references to the undefined __ROOT__ variable in unreachable rsync commands

## Validation
- bash -n tools/deploy.sh